### PR TITLE
chore: publish busy-v2 using package version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,66 @@
+name: Publish busy-v2 to npm
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    if: github.actor != 'github-actions'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    defaults:
+      run:
+        working-directory: busy-v2
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Read package version
+        id: package
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Publish busy-v2 package to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish
+
+      - name: Push tag for release
+        env:
+          VERSION: ${{ steps.package.outputs.version }}
+        run: |
+          git config user.email "github-actions@users.noreply.github.com"
+          git config user.name "github-actions"
+          git fetch origin --tags
+          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+            echo "Tag $VERSION already exists" >&2
+            exit 1
+          fi
+          git tag "$VERSION"
+          git push origin "$VERSION"
+
+      - name: Create GitHub release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.package.outputs.version }}
+          release_name: busy-v2 ${{ steps.package.outputs.version }}
+          body: |
+            Automated release for busy-v2 ${{ steps.package.outputs.version }}.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# busy-lang
+
+This repository contains the Busy language project.
+
+## Automated publishing
+
+Merges into the `main` branch automatically trigger the **Publish busy-v2 to npm** workflow.
+
+The workflow installs dependencies in the [`busy-v2`](./busy-v2) package directory, publishes that package to npm, and then creates a Git tag and GitHub release that match the version already recorded in `busy-v2/package.json` (tagged as `vX.Y.Z`). Make sure to update the package version before merging.
+
+To enable publishing, add an `NPM_TOKEN` secret in the repository settings with publish access to the `busy-v2` npm package.


### PR DESCRIPTION
## Summary
- publish busy-v2 from GitHub Actions using the version already declared in busy-v2/package.json
- push a matching Git tag and GitHub release after publishing without modifying the repository state
- document the manual versioning requirement for automated releases in the README

## Testing
- not run (workflow configuration only)

------
https://chatgpt.com/codex/tasks/task_e_68dd0b1dc6148322aed2918b2af787a7