### PR TITLE
feat: fix circular imports + View/Config canonical docs (PFM-88)

### DIFF
--- a/busy/core/config.busy.md
+++ b/busy/core/config.busy.md
@@ -50,7 +50,7 @@ Same as [Model] Rules — constraints that must hold. For configs, these are typ
 
 # [Operations](./document.busy.md#operations-section)
 
-## [initialize][./operation.busy.md]
+## [initialize](./operation.busy.md)
 
 Create the singleton config instance with defaults if it doesn't exist.
 

--- a/busy/core/config.busy.md
+++ b/busy/core/config.busy.md
@@ -50,7 +50,7 @@ Same as [Model] Rules — constraints that must hold. For configs, these are typ
 
 # [Operations](./document.busy.md#operations-section)
 
-## initialize
+## [initialize][./operation.busy.md]
 
 Create the singleton config instance with defaults if it doesn't exist.
 
@@ -73,7 +73,7 @@ Create the singleton config instance with defaults if it doesn't exist.
 - Overrides validated against rules
 - Instance persisted
 
-## getConfig
+## [getConfig](./operation.busy.md)
 
 Retrieve the current config values.
 
@@ -84,7 +84,7 @@ Retrieve the current config values.
 ### [Output][Output Section]
 - The current config instance
 
-## updateConfig
+## [updateConfig](./operation.busy.md)
 
 Modify configuration values.
 

--- a/busy/core/config.busy.md
+++ b/busy/core/config.busy.md
@@ -1,0 +1,106 @@
+---
+Name: Config
+Type: [Model]
+Description: A singleton [Model] — defines the shape of a configuration or settings object where only one instance exists per workspace. Like a [Model] but there is exactly one record, not a collection.
+---
+
+# [Imports](./document.busy.md#imports-section)
+
+[Config]:./config.busy.md
+[Model]:./model.busy.md
+[Document]:./document.busy.md
+[Operation]:./operation.busy.md
+[Input]:./operation.busy.md#input
+[Output]:./operation.busy.md#output
+[Steps]:./operation.busy.md#steps
+[Input Section]:./operation.busy.md#input-section
+[Output Section]:./operation.busy.md#output-section
+[Steps Section]:./operation.busy.md#steps-section
+[Checklist Section]:./checklist.busy.md#checklist-section
+
+# [Setup](./document.busy.md#setup-section)
+
+A [Config] is a [Model] with a singleton constraint — exactly one instance exists. Use [Config] for workspace settings, process definitions, feature flags, and any data shape where there is one authoritative record rather than a collection of instances.
+
+A [Config] inherits all of [Model]'s structure: Identity, Fields, Rules, and Persistence. The key differences are:
+- **No Lifecycle section** — configs don't transition through states
+- **No Relationships section** — configs don't reference other model instances
+- **Identity is implicit** — there is only one, identified by name
+- **createInstance is replaced by initialize** — creates the singleton if it doesn't exist
+- **listInstances is not applicable** — there is exactly one
+
+Think of a [Config] like a settings file — it defines what knobs exist and their current values, but there's only one copy.
+
+# [Local Definitions](./document.busy.md#local-definitions-section)
+
+## [Fields Section]
+[Fields Section]:./config.busy.md#fields-section
+[Fields]:./config.busy.md#fields-section
+Same as [Model] Fields — a table of field names, types, meanings, and whether they're required. Each field represents a configuration value.
+
+## [Defaults Section]
+[Defaults Section]:./config.busy.md#defaults-section
+[Defaults]:./config.busy.md#defaults-section
+Default values for each field when the config is initialized. Unlike [Model] instances which may have no defaults, every [Config] field should have a sensible default.
+
+## [Rules Section]
+[Rules Section]:./config.busy.md#rules-section
+[Rules]:./config.busy.md#rules-section
+Same as [Model] Rules — constraints that must hold. For configs, these are typically value range constraints (e.g., "port must be between 1024 and 65535") or mutual exclusion rules.
+
+# [Operations](./document.busy.md#operations-section)
+
+## initialize
+
+Create the singleton config instance with defaults if it doesn't exist.
+
+### [Input][Input Section]
+- `overrides`: Optional field values to override defaults
+
+### [Steps][Steps Section]
+1. Check if config instance already exists
+2. If exists, return existing instance
+3. If not, create with [Defaults], applying any overrides
+4. Validate [Rules]
+5. Persist via adapter
+
+### [Output][Output Section]
+- The config instance
+
+### [Checklist][Checklist Section]
+- Singleton constraint maintained
+- Defaults applied
+- Overrides validated against rules
+- Instance persisted
+
+## getConfig
+
+Retrieve the current config values.
+
+### [Steps][Steps Section]
+1. Load the singleton instance from persistence
+2. If not found, run initialize with defaults
+
+### [Output][Output Section]
+- The current config instance
+
+## updateConfig
+
+Modify configuration values.
+
+### [Input][Input Section]
+- `changes`: Fields to modify and their new values
+
+### [Steps][Steps Section]
+1. Load current config
+2. Apply changes
+3. Validate all [Rules] still hold
+4. Persist updated config
+
+### [Output][Output Section]
+- The updated config instance
+
+### [Checklist][Checklist Section]
+- Changes applied
+- All rules valid
+- Config persisted

--- a/busy/core/view.busy.md
+++ b/busy/core/view.busy.md
@@ -1,0 +1,99 @@
+---
+Name: View
+Type: [Document]
+Description: A presentation [Document] that composes and displays information from [Model]s and [Playbook]s. Follows MVC — imports provide the data, local definitions shape the view model, the display section renders the layout, and operations handle actions.
+---
+
+# [Imports](./document.busy.md#imports-section)
+
+[View]:./view.busy.md
+[Document]:./document.busy.md
+[Model]:./model.busy.md
+[Playbook]:./playbook.busy.md
+[Operation]:./operation.busy.md
+[Tool]:./tool.busy.md
+[Input]:./operation.busy.md#input
+[Output]:./operation.busy.md#output
+[Steps]:./operation.busy.md#steps
+[Input Section]:./operation.busy.md#input-section
+[Output Section]:./operation.busy.md#output-section
+[Steps Section]:./operation.busy.md#steps-section
+[Checklist Section]:./checklist.busy.md#checklist-section
+
+# [Setup](./document.busy.md#setup-section)
+
+A [View] presents information from the domain in a format optimized for consumption — whether by humans or LLM agents. Unlike a [Model] which defines what data exists, or a [Playbook] which defines how work is done, a [View] defines how information is displayed and interacted with.
+
+Views follow a Model-View-Controller pattern:
+- **Imports** bring in [Model]s and [Playbook]s as data sources
+- **Local Definitions** reshape and combine imported data into a view model
+- **Display** section defines the layout and presentation (optional — a compiler can generate a default from the view model)
+- **Operations** handle actions the user can take (refresh, filter, navigate)
+
+A [View] with a Display section is renderable — a LORE compiler can compile it into a navigable page. A [View] without a Display section is a data composition only.
+
+# [Local Definitions](./document.busy.md#local-definitions-section)
+
+## [Data Source]
+[Data Source]:./view.busy.md#data-source
+A reference to an imported [Model] or [Playbook] that provides data for this view. Each data source maps imported fields to the view model.
+
+## [View Model Field]
+[View Model Field]:./view.busy.md#view-model-field
+A field in the view model, derived from one or more [Data Source]s. Can be:
+- **Direct mapping**: field comes straight from a [Model] field
+- **Computed**: derived from multiple fields or logic (e.g., days since a date)
+- **Aggregated**: summarized across multiple instances (e.g., count, average)
+
+## [Filter]
+[Filter]:./view.busy.md#filter
+A constraint that narrows which [Model] instances are included in the view. Filters can be static (defined in the view) or dynamic (set by user actions via operations).
+
+## [Display Section]
+[Display Section]:./view.busy.md#display-section
+The presentation layout written in markdown. May include Handlebars-style placeholders (`{{field}}`, `{{#each items}}`, `{{#if condition}}`) that are resolved against the view model at render time. This section is optional — when omitted, a compiler can generate a default layout from the local definitions.
+
+# [Operations](./document.busy.md#operations-section)
+
+## renderView
+
+Compile and render this view using current data.
+
+### [Input][Input Section]
+- `data_sources`: Loaded [Model] instances from imports
+- `filters`: Active [Filter] constraints (optional)
+
+### [Steps][Steps Section]
+1. Load data from each [Data Source] via its [Model]'s persistence adapter
+2. Apply any active [Filter]s to narrow the data set
+3. Map loaded data to [View Model Field]s defined in local definitions
+4. If [Display Section] exists, resolve placeholders against the view model
+5. If no [Display Section], generate a default layout from view model fields
+6. Return rendered output
+
+### [Output][Output Section]
+- Rendered view content (markdown, HTML, or text depending on compiler)
+
+### [Checklist][Checklist Section]
+- All data sources loaded
+- Filters applied
+- View model fields resolved
+- Display rendered or generated
+
+## refreshView
+
+Reload data from sources and re-render.
+
+### [Input][Input Section]
+- `force`: Whether to bypass cache (optional, default false)
+
+### [Steps][Steps Section]
+1. Reload all [Data Source]s from their persistence adapters
+2. Re-run renderView with fresh data
+
+### [Output][Output Section]
+- Updated rendered view content
+
+### [Checklist][Checklist Section]
+- Data sources refreshed
+- View re-rendered with current data

--- a/busy/core/view.busy.md
+++ b/busy/core/view.busy.md
@@ -55,7 +55,7 @@ The presentation layout written in markdown. May include Handlebars-style placeh
 
 # [Operations](./document.busy.md#operations-section)
 
-## renderView
+## [renderView](./operation.busy.md)
 
 Compile and render this view using current data.
 
@@ -80,7 +80,7 @@ Compile and render this view using current data.
 - View model fields resolved
 - Display rendered or generated
 
-## refreshView
+## [refreshView](./operation.busy.md)
 
 Reload data from sources and re-render.
 

--- a/packages/busy-cli/src/loader.ts
+++ b/packages/busy-cli/src/loader.ts
@@ -16,7 +16,11 @@ import {
   File,
 } from './types/schema.js';
 
-/** Union of all document kinds the loader produces */
+/**
+ * Union of all top-level document variants the loader produces.
+ * Note: BusyDocument covers the generic `document` kind, including plain
+ * Document/Model-style docs that don't get a more specific classifier.
+ */
 type AnyDocument = BusyDocument | Playbook | View | Config;
 import { parseFrontMatter } from './parsers/frontmatter.js';
 import { parseSections, getAllSections, findSection } from './parsers/sections.js';

--- a/packages/busy-cli/src/loader.ts
+++ b/packages/busy-cli/src/loader.ts
@@ -15,6 +15,9 @@ import {
   Section,
   File,
 } from './types/schema.js';
+
+/** Union of all document kinds the loader produces */
+type AnyDocument = BusyDocument | Playbook | View | Config;
 import { parseFrontMatter } from './parsers/frontmatter.js';
 import { parseSections, getAllSections, findSection } from './parsers/sections.js';
 import { extractLocalDefs } from './parsers/localdefs.js';
@@ -69,7 +72,7 @@ export async function loadRepo(globs: string[]): Promise<Repo> {
 
   // Second pass: parse documents
   const files: File[] = []; // Lightweight file representations
-  const docs: (BusyDocument | Playbook | View | Config)[] = []; // Full concept definitions
+  const docs: AnyDocument[] = []; // Full concept definitions
   const allLocaldefs = new Map<string, LocalDef>();
   const allOperations = new Map<string, Operation>();
   const allImports: ImportDef[] = [];
@@ -267,7 +270,7 @@ export async function loadRepo(globs: string[]): Promise<Repo> {
   }
 
   // Inherit operations from parent documents
-  inheritOperations(docs, allOperations);
+  inheritOperations(docs as (BusyDocument | Playbook)[], allOperations);
 
   // Build concepts array (includes all documents as ConceptBase)
   const concepts: ConceptBase[] = docs.map((doc) => ({
@@ -314,7 +317,7 @@ export async function loadRepo(globs: string[]): Promise<Repo> {
   }
 
   // Build byFile index
-  const byFile: Record<string, { concept: BusyDocument | Playbook | View | Config; bySlug: Record<string, Section> }> = {};
+  const byFile: Record<string, { concept: AnyDocument; bySlug: Record<string, Section> }> = {};
 
   for (const doc of docs) {
     const bySlug: Record<string, Section> = {};
@@ -360,7 +363,7 @@ export async function loadRepo(globs: string[]): Promise<Repo> {
  * 2. Documents in the 'types' array (implicit type-based inheritance)
  */
 function inheritOperations(
-  docs: (BusyDocument | Playbook | View | Config)[],
+  docs: AnyDocument[],
   allOperations: Map<string, Operation>
 ): void {
   // Build doc lookup by name
@@ -424,7 +427,7 @@ function resolveSymbol(
   nameOrLabel: string,
   currentDocId: string,
   localdefs: Map<string, LocalDef>,
-  docs: (BusyDocument | Playbook)[],
+  docs: AnyDocument[],
   symbols: Record<string, { docId?: string; slug?: string }>
 ): string | undefined {
   // 1. Check for LocalDef in same doc

--- a/packages/busy-cli/src/parser.ts
+++ b/packages/busy-cli/src/parser.ts
@@ -217,14 +217,16 @@ export function resolveImports(
     // Resolve the import path
     const importPath = resolve(dirname(basePath), imp.path);
 
-    // Check for circular imports
+    // Check for circular imports — warn and skip instead of crashing
     if (visited.has(importPath)) {
-      throw new Error(`Circular import detected: ${importPath}`);
+      console.warn(`⚠ Circular import skipped: ${imp.path} (from ${basePath})`);
+      continue;
     }
 
-    // Check if file exists
+    // Check if file exists — warn and skip instead of crashing
     if (!existsSync(importPath)) {
-      throw new Error(`Import not found: ${imp.path} (resolved to ${importPath})`);
+      console.warn(`⚠ Import not found: ${imp.path} (resolved to ${importPath})`);
+      continue;
     }
 
     // Mark as visited
@@ -248,7 +250,7 @@ export function resolveImports(
         );
 
         if (!hasOperation && !hasDefinition) {
-          throw new Error(`Anchor '${imp.anchor}' not found in ${imp.path}`);
+          console.warn(`⚠ Anchor '${imp.anchor}' not found in ${imp.path}`);
         }
       }
 
@@ -258,10 +260,12 @@ export function resolveImports(
       // Recursively resolve imports in the imported document
       const nestedResolved = resolveImports(importedDoc, importPath, visited);
       Object.assign(resolved, nestedResolved);
-    } finally {
-      // Remove from visited after processing (allow same doc in different branches)
-      visited.delete(importPath);
+    } catch (e) {
+      // Don't crash on nested resolution failures
+      console.warn(`⚠ Failed to resolve nested imports in ${imp.path}: ${e}`);
     }
+    // NOTE: we intentionally keep importPath in `visited` — once resolved,
+    // don't re-resolve in other branches (prevents exponential recursion)
   }
 
   return resolved;

--- a/packages/busy-cli/src/types/schema.ts
+++ b/packages/busy-cli/src/types/schema.ts
@@ -160,7 +160,7 @@ type Section = {
 };
 
 type ConceptBase = {
-  kind: 'concept' | 'document' | 'operation' | 'checklist' | 'tool' | 'playbook' | 'localdef' | 'importdef' | 'setup';
+  kind: 'concept' | 'document' | 'operation' | 'checklist' | 'tool' | 'playbook' | 'view' | 'config' | 'localdef' | 'importdef' | 'setup';
   id: string;
   docId: string;
   slug: string;


### PR DESCRIPTION
## Summary

Two things in one PR:

### 1. Circular Import Fix
`busy resolve` and `resolveImports()` no longer crash on circular imports, missing files, or missing anchors. All three now warn and skip.

**Before:** `busy resolve model.busy.md` → `Error: Circular import detected`
**After:** `busy resolve model.busy.md` → `✓ Resolved 35 imports` (with warnings for circular skips)

Also fixes exponential recursion by keeping the visited set permanently — once a file is resolved, it's not re-resolved in other branches.

### 2. Canonical View & Config BUSY Documents
- `busy/core/view.busy.md` — View type (MVC: imports=Model, localDefs=ViewModel, display=View, operations=Controller)
- `busy/core/config.busy.md` — Config type (singleton Model, initialize/getConfig/updateConfig)

### loadRepo Verification
```
loadRepo(rook/**/*.busy.md) → 84 docs, 256 edges, 0 crashes
```

## Tests
```
322 passed (no regressions)
```

Task: PFM-88