### PR TITLE
feat: Lore frontmatter config on Views — Route, Permission

### DIFF
--- a/packages/busy-cli/src/__tests__/view-config.test.ts
+++ b/packages/busy-cli/src/__tests__/view-config.test.ts
@@ -91,6 +91,30 @@ Description: A view without an explicit display section
 Reload data.
 `;
 
+const VIEW_WITH_LORE = `---
+Name: Listing Detail
+Type: [View]
+Description: Competitive context for a specific listing
+Lore:
+  Route: /market-monitoring/listing/:listingId
+  Permission: premium
+---
+
+# Imports
+[Prospect]:./prospect.busy.md
+
+# Local Definitions
+
+## ListingFields
+- \`address\` — Street address
+- \`dom\` — Days on market
+
+# Display
+
+## Listing: {{address}}
+Days on market: {{dom}}
+`;
+
 const CONFIG_DOC = `---
 Name: Canon SDLC
 Type: [Config]
@@ -125,6 +149,7 @@ function setupFixtures() {
   writeFileSync(join(FIXTURES_DIR, 'prospect.busy.md'), MODEL_DOC);
   writeFileSync(join(FIXTURES_DIR, 'prospect-pipeline.busy.md'), VIEW_DOC);
   writeFileSync(join(FIXTURES_DIR, 'simple-view.busy.md'), VIEW_NO_TEMPLATE);
+  writeFileSync(join(FIXTURES_DIR, 'listing-detail.busy.md'), VIEW_WITH_LORE);
   writeFileSync(join(FIXTURES_DIR, 'canon-sdlc.busy.md'), CONFIG_DOC);
 }
 
@@ -147,8 +172,8 @@ describe('View and Config Types', () => {
   });
 
   describe('Loading', () => {
-    it('loads all 4 fixture documents', () => {
-      expect(repo.concepts.length).toBe(4);
+    it('loads all 5 fixture documents', () => {
+      expect(repo.concepts.length).toBe(5);
     });
 
     it('classifies Model as document', () => {
@@ -230,6 +255,26 @@ describe('View and Config Types', () => {
         e => e.from === viewDocId && e.role === 'imports'
       );
       expect(importEdges.length).toBeGreaterThan(0);
+    });
+
+    it('has no meta when no extra frontmatter is present', () => {
+      const viewDocId = Object.keys(repo.byFile).find(id =>
+        repo.byFile[id].concept.name === 'Prospect Pipeline'
+      )!;
+      const viewDoc = repo.byFile[viewDocId].concept;
+      expect(viewDoc.meta).toBeUndefined();
+    });
+
+    it('carries extra frontmatter through as meta (generic passthrough)', () => {
+      const viewDocId = Object.keys(repo.byFile).find(id =>
+        repo.byFile[id].concept.name === 'Listing Detail'
+      )!;
+      const viewDoc = repo.byFile[viewDocId].concept;
+      expect(viewDoc.meta).toBeDefined();
+      expect((viewDoc.meta as any).Lore).toEqual({
+        Route: '/market-monitoring/listing/:listingId',
+        Permission: 'premium',
+      });
     });
   });
 

--- a/packages/busy-cli/src/loader.ts
+++ b/packages/busy-cli/src/loader.ts
@@ -229,6 +229,15 @@ export async function loadRepo(globs: string[]): Promise<Repo> {
     const isView = typesLower.includes('view');
     const isConfig = typesLower.includes('config');
 
+    // Collect extra frontmatter fields as meta for downstream consumers
+    const KNOWN_FRONTMATTER_KEYS = new Set(['Name', 'Type', 'Extends', 'Description', 'Tags']);
+    const meta: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(parts.frontmatter)) {
+      if (!KNOWN_FRONTMATTER_KEYS.has(key)) {
+        meta[key] = value;
+      }
+    }
+
     // Base fields shared across all document kinds
     const baseFields = {
       id: parts.docId,
@@ -243,6 +252,7 @@ export async function loadRepo(globs: string[]): Promise<Repo> {
       localdefs: parts.localdefs,
       setup: parts.setup!,
       operations: parts.operations,
+      ...(Object.keys(meta).length > 0 ? { meta } : {}),
     };
 
     if (isPlaybook) {

--- a/packages/busy-cli/src/types/schema.ts
+++ b/packages/busy-cli/src/types/schema.ts
@@ -203,6 +203,7 @@ const ConceptBaseSchemaObject = z.object({
   types: z.array(ConceptIdSchema),
   extends: z.array(ConceptIdSchema),
   sectionRef: SectionIdSchema,
+  meta: z.record(z.unknown()).optional(),  // Extra frontmatter for downstream consumers
 });
 
 export const ConceptBaseSchema: z.ZodType<ConceptBase> = z.lazy(() =>
@@ -265,7 +266,7 @@ export const PlaybookSchema = LegacyBusyDocumentSchema.extend({
 // Views follow MVC: imports=Model, localDefs=ViewModel, template=View, operations=Controller
 export const ViewSchema = LegacyBusyDocumentSchema.extend({
     kind: z.literal('view'),
-    display: z.string().optional(), // Markdown template (optional — LORE can generate)
+    display: z.string().optional(),           // Markdown template (optional — LORE can generate)
   })
 
 // Config schema - extends LegacyBusyDocument, semantically a singleton Model
@@ -378,6 +379,6 @@ export const FrontMatterSchema = z.object({
       if (typeof val === 'string') return [val];
       return val;
     }),
-});
+}).passthrough();  // Preserve unknown fields for downstream consumers (Lore, Knit, etc.)
 
 export type FrontMatter = z.infer<typeof FrontMatterSchema>;


### PR DESCRIPTION
Adds `Lore:` frontmatter namespace for View-specific LORE config.

- `Lore.Route`: explicit route override with `:param` syntax
- `Lore.Permission`: required permission level
- `LoreViewConfigSchema` with `.passthrough()` for forward compat
- Carried through loader → View concept → exported type

Tests: 329 passed

Task: PFM-104