### PR TITLE
feat(docs): LORE documentation site views for BUSY authoring & CLI

### DIFF
--- a/docs/views/cli/graph.busy.md
+++ b/docs/views/cli/graph.busy.md
@@ -1,0 +1,147 @@
+---
+Name: Graph Command
+Type: [View]
+Description: How to use the busy graph command to visualize workspace dependencies — JSON, tree, and DOT output formats.
+---
+
+# Imports
+
+[View]:../../../busy/core/view.busy.md
+[Document]:../../../busy/core/document.busy.md
+[CLI Overview]:./overview.busy.md
+[Home]:../home.busy.md
+
+# Setup
+
+This view covers the `busy graph` command — how to generate, filter, and interpret workspace dependency graphs.
+
+# Display
+
+## Graph Command
+
+`busy graph` outputs the full dependency graph of a BUSY workspace. It discovers all `.busy.md` files, parses their imports, and produces a graph of nodes (documents) and edges (relationships).
+
+### Basic Usage
+
+```bash
+busy graph [directory]
+```
+
+Defaults to the current directory. Output defaults to JSON.
+
+### Options
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--format <format>` | Output format: `json`, `tree`, or `dot` | `json` |
+| `--filter <type>` | Filter nodes by type (e.g., `Model`, `View`, `Playbook`) | none |
+| `-o, --output <file>` | Write output to a file instead of stdout | stdout |
+
+### Output Formats
+
+#### Tree Format
+
+The most readable format for quick inspection:
+
+```bash
+busy graph --format tree
+```
+
+```
+my-workspace (15 documents, 42 edges)
+├── core/ (3 docs)
+│   ├── [Concept] Document (8 importers, 2 imports)
+│   ├── [Concept] Operation (6 importers, 1 imports)
+│   └── [Document] Checklist (4 importers, 1 imports)
+├── models/ (4 docs)
+│   ├── [Model] Customer (3 importers, 2 imports)
+│   └── [Model] Order (2 importers, 3 imports)
+├── playbooks/ (2 docs)
+│   └── [Playbook] Onboarding (0 importers, 5 imports)
+└── views/ (2 docs)
+    └── [View] Dashboard (0 importers, 4 imports)
+```
+
+Each node shows:
+- **Type** in brackets
+- **Name** from frontmatter
+- **Importers** — how many other documents import this one
+- **Imports** — how many documents this one imports
+
+#### DOT Format
+
+For Graphviz visualization:
+
+```bash
+busy graph --format dot > workspace.dot
+dot -Tpng workspace.dot -o workspace.png
+```
+
+Produces a directed graph where:
+- Nodes are labeled `[Type] Name`
+- Edges are labeled with the relationship type (`imports`, `calls`, `ref`, `extends`)
+
+#### JSON Format
+
+Full machine-readable output with statistics:
+
+```bash
+busy graph --format json -o graph.json
+```
+
+The JSON includes:
+- `workspace` — workspace name
+- `stats` — document count, edge count, type distribution, orphans, circular imports
+- `nodes` — array of all documents with type, path, import/importer counts
+- `edges` — array of all relationships with from, to, and role
+
+### Filtering by Type
+
+Focus on specific document types:
+
+```bash
+# Show only Models
+busy graph --filter Model --format tree
+
+# Show only Views
+busy graph --filter View --format tree
+
+# Show only Playbooks
+busy graph --filter Playbook --format tree
+```
+
+The filter matches against the document's Type field (case-insensitive).
+
+### Graph Statistics
+
+The JSON output includes useful statistics:
+
+| Stat | Meaning |
+|------|---------|
+| `documents` | Total number of `.busy.md` files |
+| `edges` | Total relationships between documents |
+| `importEdges` | Import-specific edges |
+| `types` | Count of documents by type |
+| `orphans` | Documents with no imports and no importers |
+| `mostImported` | Top 5 most-imported documents |
+| `circularImports` | Detected circular import chains |
+
+### Interpreting the Graph
+
+**Orphaned documents** (no imports, no importers) may indicate:
+- A document that's not integrated into the workspace
+- A standalone reference that should be imported somewhere
+- A file that can be safely removed
+
+**Circular imports** are detected and reported but don't prevent the graph from building. They may indicate:
+- Two documents that should be merged
+- A missing abstraction that both documents depend on
+
+**High importer count** indicates a foundational document — changes to it affect many dependents.
+
+### Tips
+
+- **Run `busy graph --format tree` regularly** — it's the quickest way to understand workspace structure
+- **Check for orphans** — they often indicate missing imports or dead documents
+- **Use DOT format for documentation** — generate visual diagrams for team onboarding
+- **Filter by type when debugging** — narrow focus to just Models, Views, etc.

--- a/docs/views/cli/overview.busy.md
+++ b/docs/views/cli/overview.busy.md
@@ -1,0 +1,118 @@
+---
+Name: CLI Overview
+Type: [View]
+Description: Overview of all available busy CLI commands — parse, validate, resolve, graph, init, check, and package management.
+---
+
+# Imports
+
+[View]:../../../busy/core/view.busy.md
+[Document]:../../../busy/core/document.busy.md
+[Validate Command]:./validate.busy.md
+[Graph Command]:./graph.busy.md
+[Workspace Commands]:./workspace-commands.busy.md
+[Home]:../home.busy.md
+
+# Setup
+
+This view provides a reference of all commands available in the `busy` CLI.
+
+# Display
+
+## CLI Overview
+
+The `busy` CLI (`@busy/parser`) parses BUSY markdown workspaces into a typed graph. Install it with:
+
+```bash
+npm install -g @busy/parser
+```
+
+### Command Summary
+
+| Command | Purpose |
+|---------|---------|
+| `busy parse <file>` | Parse a document and output its structure as JSON |
+| `busy validate <file>` | Validate a document's frontmatter, structure, and imports |
+| `busy resolve <file>` | Resolve all imports in a document recursively |
+| `busy graph [directory]` | Output the workspace dependency graph |
+| `busy info <file>` | Show quick document information |
+| `busy init` | Initialize a new workspace with `package.busy.md` |
+| `busy check` | Validate workspace coherence (packages, links, integrity) |
+| `busy package add <url>` | Add a package from URL or local folder |
+| `busy package remove <name>` | Remove a package |
+| `busy package upgrade [name]` | Upgrade packages to latest version |
+| `busy package list` | List installed packages |
+| `busy package info <name>` | Show package details |
+
+### Document Commands
+
+These commands operate on individual `.busy.md` files:
+
+**Parse** — Extract the full structure as JSON:
+```bash
+busy parse ./models/customer.busy.md -o customer.json
+```
+Output includes metadata, imports, definitions, operations, and triggers.
+
+**Validate** — Check a document is structurally correct:
+```bash
+busy validate ./models/customer.busy.md
+busy validate ./models/customer.busy.md --resolve-imports
+```
+With `--resolve-imports`, also verifies that all imported files can be found and parsed.
+
+**Resolve** — Recursively resolve all imports:
+```bash
+busy resolve ./playbooks/onboarding.busy.md --flat
+```
+Shows the full dependency tree of a document.
+
+**Info** — Quick summary of a document:
+```bash
+busy info ./models/customer.busy.md
+```
+Shows name, type, description, imports, definitions, operations, and triggers at a glance.
+
+For detailed usage, see:
+- [Validate Command](./validate.busy.md) — validation options and error patterns
+- [Graph Command](./graph.busy.md) — graph formats and filtering
+
+### Workspace Commands
+
+These commands operate on the workspace as a whole:
+
+**Init** — Create a new workspace:
+```bash
+busy init
+busy init -d ./my-workspace
+```
+
+**Check** — Validate workspace integrity:
+```bash
+busy check
+busy check -d ./my-workspace
+```
+
+**Graph** — Visualize the full workspace:
+```bash
+busy graph --format tree
+busy graph --format dot > workspace.dot
+busy graph --filter Model
+```
+
+For detailed usage, see [Workspace Commands](./workspace-commands.busy.md).
+
+### Package Commands
+
+Manage external dependencies:
+
+```bash
+busy package add ../shared-library/busy    # local folder
+busy package add https://github.com/...    # remote URL
+busy package list                          # show installed
+busy package remove busy-v2                # remove
+busy package upgrade --all                 # upgrade all
+busy package info busy-v2                  # details
+```
+
+For detailed usage, see [Workspace Commands](./workspace-commands.busy.md).

--- a/docs/views/cli/validate.busy.md
+++ b/docs/views/cli/validate.busy.md
@@ -1,0 +1,103 @@
+---
+Name: Validate Command
+Type: [View]
+Description: How to use the busy validate command to check BUSY documents for structural errors, broken imports, and missing sections.
+---
+
+# Imports
+
+[View]:../../../busy/core/view.busy.md
+[Document]:../../../busy/core/document.busy.md
+[CLI Overview]:./overview.busy.md
+[Home]:../home.busy.md
+
+# Setup
+
+This view covers the `busy validate` command in detail — its options, what it checks, and how to interpret its output.
+
+# Display
+
+## Validate Command
+
+`busy validate` checks a BUSY document for structural correctness. It's the first tool to run when authoring or debugging a document.
+
+### Basic Usage
+
+```bash
+busy validate <file>
+```
+
+Example:
+```bash
+busy validate ./models/customer.busy.md
+```
+
+Output on success:
+```
+✓ Valid BUSY document: Customer
+  Type: Model
+  Description: Represents a customer in the system...
+
+✓ Validation passed
+```
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `--resolve-imports` | Also validate that all imports can be resolved to real files |
+
+### What Gets Checked
+
+The validate command checks these aspects of a document:
+
+**1. Frontmatter**
+- `---` delimiters present at the top of the file
+- `Name` field exists and is a non-empty string
+- `Type` field exists (e.g., `[Document]`, `[Model]`, `[View]`)
+- `Description` field exists
+
+**2. Structure**
+- The document can be parsed as valid Markdown
+- Sections follow the expected heading hierarchy
+- Standard sections are recognizable (Imports, Setup, Local Definitions, Operations)
+
+**3. Operations**
+- Operations have parseable step lists
+- Warning if an operation has zero steps
+
+**4. Imports** (with `--resolve-imports`)
+- Each import path resolves to a real file
+- Imported files are themselves valid BUSY documents
+- Anchor references resolve to actual headings
+
+### Interpreting Output
+
+**Warnings** (⚠) are non-fatal observations:
+```
+⚠ Operation "processOrder" has no steps
+⚠ Document has operations but no imports
+```
+
+**Errors** (✗) mean the document is invalid:
+```
+✗ File not found: ./models/missing.busy.md
+✗ Validation failed: Missing required frontmatter field: Name
+✗ Import resolution failed: Cannot resolve ./broken-path.busy.md
+```
+
+### Common Validation Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Missing frontmatter | No `---` delimiters at top | Add YAML frontmatter with Name, Type, Description |
+| Missing required field | Frontmatter lacks Name, Type, or Description | Add the missing field |
+| Import resolution failed | Path doesn't resolve to a file | Fix the relative path or create the target file |
+| Anchor not found | `#anchor` doesn't match any heading | Check heading text and anchor casing |
+
+### Workflow Tips
+
+- **Run validate early and often** — catch structural issues before they cascade
+- **Use `--resolve-imports` before committing** — ensures no broken links
+- **Combine with `busy check`** — validate checks one file, check validates the whole workspace
+- **Pipe to CI** — `busy validate` exits with code 1 on failure, making it CI-friendly

--- a/docs/views/cli/workspace-commands.busy.md
+++ b/docs/views/cli/workspace-commands.busy.md
@@ -1,0 +1,189 @@
+---
+Name: Workspace Commands
+Type: [View]
+Description: How to use busy init, busy check, and busy package commands to manage workspaces and dependencies.
+---
+
+# Imports
+
+[View]:../../../busy/core/view.busy.md
+[Document]:../../../busy/core/document.busy.md
+[Workspace]:../../../busy/core/workspace.busy.md
+[CLI Overview]:./overview.busy.md
+[Home]:../home.busy.md
+
+# Setup
+
+This view covers the workspace-level CLI commands: `busy init`, `busy check`, and the `busy package` subcommands.
+
+# Display
+
+## Workspace Commands
+
+These commands operate on the workspace as a whole — initializing structure, checking integrity, and managing external package dependencies.
+
+### busy init
+
+Create a new BUSY workspace:
+
+```bash
+busy init
+busy init -d ./my-workspace
+```
+
+**What it creates:**
+- `package.busy.md` — the workspace manifest (a `[Package]` type document)
+- `.libraries/` — directory for cached external packages
+
+If either already exists, it's skipped. This is safe to run in an existing workspace.
+
+### busy check
+
+Validate workspace coherence — verifying that all declared packages exist and their cached files are intact:
+
+```bash
+busy check
+busy check -d ./my-workspace
+```
+
+**What it checks:**
+- Every package in `package.busy.md` has a corresponding cached file in `.libraries/`
+- File integrity hashes match (if recorded)
+- No missing or corrupted dependencies
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `-d, --dir <directory>` | Workspace directory (default: `.`) |
+| `--skip-external` | Skip validation of external URLs |
+| `-v, --verbose` | Show all checks, not just errors |
+
+**Output:**
+```
+Checking workspace...
+
+  Dependencies: 3
+
+✓ Workspace is coherent
+```
+
+Or with errors:
+```
+Checking workspace...
+
+  Dependencies: 3
+
+Errors:
+  ✗ Package "shared-models": cached file not found at .libraries/shared-models/models.busy.md
+
+✗ Workspace has errors
+```
+
+### busy package add
+
+Add an external package from a local folder or URL:
+
+```bash
+# Add from a local directory (uses package.busy.md manifest)
+busy package add ../busy-lang/busy
+
+# Add from a local directory (recursive file discovery)
+busy package add ../shared-models -r
+
+# Add a single file from a URL
+busy package add https://raw.githubusercontent.com/org/repo/main/core/document.busy.md
+```
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `-d, --dir <directory>` | Workspace directory |
+| `-r, --recursive` | Recursively add all files from a local folder |
+
+**How it works:**
+1. Detects the source type (local folder with manifest, local folder without, or URL)
+2. Fetches the content
+3. Saves to `.libraries/` with an integrity hash
+4. Records the entry in `package.busy.md`
+
+### busy package remove
+
+Remove a package:
+
+```bash
+busy package remove <package-id>
+```
+
+Removes the entry from `package.busy.md` and deletes cached files from `.libraries/`.
+
+### busy package upgrade
+
+Upgrade packages to their latest version:
+
+```bash
+# Upgrade a specific package
+busy package upgrade busy-v2
+
+# Upgrade all packages
+busy package upgrade --all
+```
+
+Shows version changes:
+```
+Checking for updates...
+
+  ✓ busy-v2: 1.0.0 → 1.1.0
+  - shared-models: 2.0.0 (up to date)
+
+✓ Upgraded 1 package(s)
+```
+
+### busy package list
+
+Show all installed packages:
+
+```bash
+busy package list
+```
+
+Output:
+```
+Dependencies:
+  busy-v2              1.0.0        local      .libraries/busy-v2/
+  shared-models        2.0.0        github     .libraries/shared-models/
+
+Total: 2 dependency(s)
+```
+
+### busy package info
+
+Show details about a specific package:
+
+```bash
+busy package info busy-v2
+```
+
+Output:
+```
+Package: busy-v2
+
+| Field     | Value |
+|-----------|-------|
+| Source    | ../busy-lang/busy |
+| Provider  | local |
+| Cached    | .libraries/busy-v2/ |
+| Version   | 1.0.0 |
+| Fetched   | 2026-03-20T14:30:00.000Z |
+| Integrity | sha256-abc123... |
+```
+
+### Typical Workflow
+
+1. **Initialize:** `busy init` to create the workspace manifest
+2. **Add dependencies:** `busy package add` for external packages you need
+3. **Author documents:** Create `.busy.md` files that import from `.libraries/`
+4. **Check integrity:** `busy check` to verify nothing is broken
+5. **Inspect structure:** `busy graph --format tree` to see the full graph
+6. **Keep updated:** `busy package upgrade --all` periodically

--- a/docs/views/guides/document-authoring.busy.md
+++ b/docs/views/guides/document-authoring.busy.md
@@ -1,0 +1,193 @@
+---
+Name: Document Authoring Guide
+Type: [View]
+Description: Step-by-step guide to writing a BUSY document — frontmatter, imports, sections, operations, and checklists.
+---
+
+# Imports
+
+[View]:../../../busy/core/view.busy.md
+[Document]:../../../busy/core/document.busy.md
+[Operation]:../../../busy/core/operation.busy.md
+[Checklist]:../../../busy/core/checklist.busy.md
+[Home]:../home.busy.md
+
+# Setup
+
+This guide walks through creating a BUSY document from scratch. It covers the required structure, section ordering, and authoring conventions.
+
+# Display
+
+## Document Authoring Guide
+
+Every BUSY document follows a fixed structure that parsers, agents, and the CLI all depend on. This guide covers each section in order.
+
+### 1. Frontmatter
+
+Every BUSY file starts with YAML frontmatter delimited by `---`. Three fields are required:
+
+```yaml
+---
+Name: My Document
+Type: [Playbook]
+Description: A brief description of what this document defines.
+---
+```
+
+**Rules:**
+- `Name` — a human-readable name for the document
+- `Type` — a bracketed reference to the BUSY type (e.g., `[Document]`, `[Model]`, `[View]`, `[Playbook]`, `[Tool]`, `[Config]`, `[Checklist]`, `[Concept]`)
+- `Description` — one or two sentences explaining purpose
+
+The parser rejects documents with missing or malformed frontmatter.
+
+### 2. Imports Section
+
+Immediately after frontmatter, define imports using reference-style Markdown links:
+
+```markdown
+# Imports
+
+[Document]:./core/document.busy.md
+[Operation]:./core/operation.busy.md
+[MyModel]:./models/customer.busy.md
+[Steps]:./core/operation.busy.md#steps-section
+```
+
+**Rules:**
+- One import per line in the format `[Alias]:relative/path.busy.md`
+- Paths must resolve to real files. The parser halts on broken imports.
+- Use `#anchor` to reference a specific heading within the target file
+- The `# Imports` heading must appear even if there are no external imports
+- Only import assets that exist. For future concepts, mention them in prose instead.
+
+### 3. Setup Section
+
+The Setup section establishes prerequisites and context. Agents always process this section before executing any operations.
+
+```markdown
+# Setup
+
+This playbook requires access to the customer database. 
+Ensure the Data Tool is configured before running any operations.
+```
+
+If no setup is needed, say so explicitly:
+
+```markdown
+# Setup
+
+No setup required.
+```
+
+### 4. Local Definitions Section
+
+Introduce new concepts under `# Local Definitions` using level-2 headings. These become addressable nodes that other files can reference.
+
+```markdown
+# Local Definitions
+
+## Priority Level
+A classification for incoming requests: Low, Medium, High, or Critical.
+
+## Escalation Threshold
+The number of hours before an unresolved request is automatically escalated.
+```
+
+**Rules:**
+- Each definition uses a `##` heading with a descriptive name
+- Definitions should be self-contained explanations
+- Other documents can import and reference these definitions by anchor
+- Keep definitions under Local Definitions — don't scatter them through other sections
+
+### 5. Operations Section
+
+Operations are the callable units of work. Each operation has a name, optional inputs, ordered steps, optional outputs, and an optional checklist.
+
+```markdown
+# Operations
+
+## reviewRequest
+
+### Input
+- `request_id`: The ID of the request to review
+- `urgency`: Priority level override (optional)
+
+### Steps
+1. Retrieve the request by ID from the data store
+2. Evaluate the request content against the review criteria
+3. Assign a priority level based on the evaluation
+4. Record the review decision in the audit log
+
+### Output
+- Review decision with assigned priority and reviewer notes
+
+### Checklist
+- Request retrieved successfully
+- Priority assigned
+- Decision logged
+```
+
+**Rules:**
+- Operation names use `##` headings with verb-noun clarity (e.g., `reviewRequest`, `generateReport`)
+- Steps are numbered and imperative — tell the agent exactly what to do
+- Inputs and Outputs use `###` subheadings within the operation
+- Checklists are acceptance criteria — observable, evidence-based items an agent can verify
+- Reference imported concepts in steps rather than embedding their logic inline
+
+### Complete Example
+
+Here is a minimal but complete BUSY document:
+
+```markdown
+---
+Name: Invoice Processor
+Type: [Document]
+Description: Processes incoming invoices and routes them for approval.
+---
+
+# Imports
+
+[Document]:./core/document.busy.md
+[Operation]:./core/operation.busy.md
+
+# Setup
+
+This document handles invoice processing. Requires access to 
+the accounting system and the approval workflow.
+
+# Local Definitions
+
+## Approval Threshold
+Invoices above $10,000 require director-level approval. 
+Below that amount, manager approval is sufficient.
+
+# Operations
+
+## processInvoice
+
+### Input
+- `invoice_data`: The raw invoice to process
+
+### Steps
+1. Validate the invoice has all required fields (vendor, amount, date)
+2. Check the amount against the Approval Threshold
+3. Route to the appropriate approver based on the threshold
+4. Record the routing decision
+
+### Output
+- Routing confirmation with approver assignment
+
+### Checklist
+- All required fields present
+- Correct approver assigned based on threshold
+- Routing recorded in audit trail
+```
+
+### Common Mistakes
+
+- **Missing `# Imports` heading** — The heading is required even with zero imports
+- **Inline links instead of reference links** — Use `[Concept]:path` at the top, then `[Concept]` in body text
+- **Self-referential anchors** — Section links must not point back to the same heading
+- **Steps without numbers** — Steps must be a numbered list, not bullets
+- **Duplicate concept names** — Every concept should map to exactly one definition or import

--- a/docs/views/guides/imports-and-linking.busy.md
+++ b/docs/views/guides/imports-and-linking.busy.md
@@ -1,0 +1,144 @@
+---
+Name: Imports and Linking Guide
+Type: [View]
+Description: How BUSY documents reference each other — import syntax, anchor resolution, and linking conventions.
+---
+
+# Imports
+
+[View]:../../../busy/core/view.busy.md
+[Document]:../../../busy/core/document.busy.md
+[Concept]:../../../busy/core/concept.busy.md
+[Home]:../home.busy.md
+
+# Setup
+
+This guide covers how BUSY documents reference and link to each other through imports, how the parser resolves paths, and best practices for maintaining a clean import graph.
+
+# Display
+
+## Imports and Linking
+
+BUSY documents form a typed graph through reference-style Markdown imports. The parser resolves every import at load time — broken links are treated as errors, not warnings.
+
+### Import Syntax
+
+Imports are reference-style Markdown link definitions placed immediately after the frontmatter:
+
+```markdown
+[Alias]:relative/path/to/file.busy.md
+[Alias With Anchor]:relative/path/to/file.busy.md#section-name
+```
+
+**The alias** (text in brackets) is the name you'll use throughout the document to refer to the imported concept. Choose clear, descriptive aliases:
+
+```markdown
+# Good — clear what each import is
+[Customer Model]:./models/customer.busy.md
+[Order Processing]:./playbooks/order-processing.busy.md
+
+# Bad — ambiguous aliases
+[Doc1]:./models/customer.busy.md
+[Ref]:./playbooks/order-processing.busy.md
+```
+
+### Path Resolution
+
+All paths are **relative** to the importing file's location:
+
+```
+workspace/
+├── core/
+│   └── document.busy.md
+├── models/
+│   └── customer.busy.md
+└── playbooks/
+    └── onboarding.busy.md    ← importing from here
+```
+
+From `playbooks/onboarding.busy.md`:
+```markdown
+[Document]:../core/document.busy.md        ← go up one level, into core/
+[Customer]:../models/customer.busy.md      ← go up one level, into models/
+```
+
+### Anchor References
+
+Use `#anchor` to reference a specific heading within the target file. Anchors follow standard Markdown heading-to-anchor conversion (lowercase, hyphens for spaces):
+
+```markdown
+[Input Section]:../core/operation.busy.md#input-section
+[Steps]:../core/operation.busy.md#steps-section
+[Lifecycle]:./models/order.busy.md#lifecycle-section
+```
+
+The parser verifies the anchor resolves to an actual heading in the target file. Broken anchors halt execution.
+
+### File Extension Rules
+
+- BUSY documents use the `.busy.md` extension
+- Import references to `.md` files automatically resolve to `.busy.md` if available
+- Non-BUSY files (e.g., `README.md`, `CLAUDE.md`) should not be imported
+
+### Using Imports in Body Text
+
+After defining imports at the top, use the alias in square brackets throughout the document:
+
+```markdown
+# Imports
+
+[Customer]:./models/customer.busy.md
+[Order]:./models/order.busy.md
+
+# Setup
+
+This playbook processes a [Customer]'s [Order] through the
+fulfillment pipeline.
+
+# Operations
+
+## fulfillOrder
+
+### Steps
+1. Retrieve the [Customer] record
+2. Validate the [Order] has all required fields
+3. Submit the [Order] for processing
+```
+
+### Cross-Reference Patterns
+
+**Importing specific operations:**
+```markdown
+[EvaluateDocument]:./core/document.busy.md#evaluatedocument
+```
+
+**Importing local definitions from another file:**
+```markdown
+[Priority Level]:./shared/definitions.busy.md#priority-level
+```
+
+**Importing type definitions (for Type field in frontmatter):**
+```markdown
+[Playbook]:./core/playbook.busy.md
+```
+
+### Edge Types in the Graph
+
+When the CLI builds a workspace graph, imports create typed edges:
+
+| Edge Type | Meaning |
+|-----------|---------|
+| `imports` | Document A imports Document B |
+| `calls` | An operation calls another operation |
+| `extends` | A local definition extends an imported definition |
+| `ref` | A general reference link to another document |
+
+Use `busy graph --format tree` to see all edges in your workspace.
+
+### Best Practices
+
+- **Prefer reference definitions** at the top of the file — reuse them in prose. Inline links are harder for the parser to track.
+- **Only import existing assets** — if you need to mention a future concept, reference it in prose without creating an import
+- **Avoid duplicate concept names** — each concept should map to one definition or import
+- **Keep imports organized** — group by category (types, models, operations) with blank lines between groups
+- **Use the formatting checklist** — run the Busy Formatting Rules checklist after drafting or revising a document to catch broken imports

--- a/docs/views/guides/workspace-setup.busy.md
+++ b/docs/views/guides/workspace-setup.busy.md
@@ -1,0 +1,188 @@
+---
+Name: Workspace Setup Guide
+Type: [View]
+Description: How to initialize, structure, and configure a BUSY workspace — folder layout, package management, and validation.
+---
+
+# Imports
+
+[View]:../../../busy/core/view.busy.md
+[Workspace]:../../../busy/core/workspace.busy.md
+[Document]:../../../busy/core/document.busy.md
+[Home]:../home.busy.md
+
+# Setup
+
+This guide covers how to create and organize a BUSY workspace — the folder that holds your documents, manages dependencies, and can be validated as a coherent unit.
+
+# Display
+
+## Workspace Setup Guide
+
+A BUSY workspace is a directory of `.busy.md` files that form a typed graph. The `busy` CLI provides commands to initialize, validate, and inspect workspaces.
+
+### Initializing a Workspace
+
+Use the CLI to create a new workspace:
+
+```bash
+busy init
+```
+
+This creates:
+- `package.busy.md` — the workspace manifest (lists dependencies)
+- `.libraries/` — cached external packages
+
+You can also initialize in a specific directory:
+
+```bash
+busy init -d ./my-workspace
+```
+
+### Workspace Layout
+
+A typical workspace is organized by domain or function:
+
+```
+my-workspace/
+├── package.busy.md          # Workspace manifest
+├── .libraries/              # Cached external packages
+├── core/                    # Shared types and concepts
+│   ├── document.busy.md
+│   └── operation.busy.md
+├── models/                  # Domain models
+│   ├── customer.busy.md
+│   └── order.busy.md
+├── playbooks/               # Orchestration flows
+│   └── onboarding.busy.md
+├── views/                   # Presentation layers
+│   └── dashboard.busy.md
+└── tools/                   # External capability wrappers
+    └── email-tool.busy.md
+```
+
+There's no enforced folder structure — organize by whatever makes sense for your domain. The parser discovers all `.busy.md` files recursively.
+
+### Package Management
+
+Workspaces can import external BUSY packages. The `busy-v2` standard library is the most common dependency.
+
+**Add a package:**
+```bash
+# From a local folder
+busy package add ../busy-lang/busy
+
+# From a local folder (recursive discovery)
+busy package add ../shared-models -r
+
+# From a URL
+busy package add https://github.com/org/repo/blob/main/busy/package.busy.md
+```
+
+**List installed packages:**
+```bash
+busy package list
+```
+
+**Remove a package:**
+```bash
+busy package remove busy-v2
+```
+
+**Upgrade packages:**
+```bash
+# Upgrade a specific package
+busy package upgrade busy-v2
+
+# Upgrade all packages
+busy package upgrade --all
+```
+
+**Get package details:**
+```bash
+busy package info busy-v2
+```
+
+Packages are cached in `.libraries/` and tracked in `package.busy.md`.
+
+### The Package Manifest
+
+`package.busy.md` is a BUSY document of type `[Package]`. It lists your workspace's external dependencies with their sources, versions, and cache locations. The CLI manages this file automatically — you rarely need to edit it by hand.
+
+### Validating the Workspace
+
+Check that your workspace is structurally coherent:
+
+```bash
+busy check
+```
+
+This verifies:
+- All packages in `package.busy.md` have cached files
+- Cached file integrity matches recorded hashes
+- No missing or broken dependencies
+
+Add `-d` for a specific directory:
+```bash
+busy check -d ./my-workspace
+```
+
+### Working with the `.workspace` File
+
+For execution-oriented workspaces (not just documentation), a `.workspace` JSON file configures how agents execute the workspace:
+
+```json
+{
+  "name": "content-generation",
+  "type": "workspace",
+  "version": "1.0",
+  "framework": "claude",
+  "hasRole": true,
+  "hasSteps": false,
+  "inputSource": "input",
+  "outputDestination": "output"
+}
+```
+
+Key fields:
+- `name` — workspace name
+- `type` — always `"workspace"`
+- `framework` — which agent framework to use (`claude`, `openai`, etc.)
+- `hasRole` — whether a `role.busy.md` file exists
+- `hasSteps` — whether the workspace has multi-step execution
+
+### Workspace Types
+
+| Type | Description | Indicators |
+|------|-------------|------------|
+| Simple | Single operation, no steps or role | No role, no steps |
+| Role-Based | Includes `role.busy.md` | `hasRole: true` |
+| Multi-Step | Sequential step folders | `hasSteps: true`, step folders |
+| Nested | Contains sub-workspaces | Folders with their own `.workspace` |
+| Hybrid | Combination of steps + nesting | Both steps and nested workspaces |
+
+### Recursive Workspaces
+
+Workspaces are fractal — any workspace can contain sub-workspaces that follow the same structure:
+
+```
+project/
+├── .workspace
+├── instructions.busy.md
+└── phase-1/
+    ├── .workspace
+    ├── instructions.busy.md
+    └── research/
+        ├── .workspace
+        └── instructions.busy.md
+```
+
+Each sub-workspace is fully independent with its own configuration, instructions, and state.
+
+### Tips
+
+- **Start simple** — a folder of `.busy.md` files with `package.busy.md` is a valid workspace
+- **Use `busy check`** after adding or removing packages to catch broken references
+- **Use `busy graph`** to visualize your workspace structure and catch orphaned documents
+- **Put shared types in a `core/` folder** — models, playbooks, and views import from there
+- **All BUSY documents must use `.busy.md`** — the parser ignores plain `.md` files

--- a/docs/views/home.busy.md
+++ b/docs/views/home.busy.md
@@ -1,0 +1,57 @@
+---
+Name: BUSY Documentation
+Type: [View]
+Description: Home page for the BUSY language documentation — authoring guides, CLI reference, and core type overview.
+---
+
+# Imports
+
+[View]:../../busy/core/view.busy.md
+[Document]:../../busy/core/document.busy.md
+[Document Authoring]:./guides/document-authoring.busy.md
+[Workspace Setup]:./guides/workspace-setup.busy.md
+[Imports and Linking]:./guides/imports-and-linking.busy.md
+[CLI Overview]:./cli/overview.busy.md
+[Validate Command]:./cli/validate.busy.md
+[Graph Command]:./cli/graph.busy.md
+[Core Types]:./reference/core-types.busy.md
+[Workspace Structure]:./reference/workspace-structure.busy.md
+
+# Setup
+
+This view is the entry point for the BUSY documentation site. It provides navigation to authoring guides, CLI reference, and core type documentation.
+
+# Display
+
+## Welcome to BUSY
+
+BUSY treats Markdown as a typed language for modeling business operations. Every document, link, and heading is structured so that both humans and LLM agents can read, validate, and execute it deterministically.
+
+A BUSY document is a Markdown file with:
+- **YAML frontmatter** declaring Name, Type, and Description
+- **Reference-style imports** linking to other BUSY documents
+- **Standard sections** (Setup, Local Definitions, Operations) following a fixed evaluation order
+- **The `.busy.md` extension** so parsers and tools can identify it
+
+### Getting Started
+
+If you're new to BUSY, start here:
+
+- [Document Authoring Guide](./guides/document-authoring.busy.md) — How to write a `.busy.md` file from scratch
+- [Imports and Linking](./guides/imports-and-linking.busy.md) — How documents reference each other
+- [Workspace Setup](./guides/workspace-setup.busy.md) — How to organize files into a workspace
+
+### CLI Reference
+
+The `busy` CLI parses, validates, and graphs your workspace:
+
+- [CLI Overview](./cli/overview.busy.md) — All available commands at a glance
+- [Validate Command](./cli/validate.busy.md) — Check documents for structural errors
+- [Graph Command](./cli/graph.busy.md) — Visualize workspace dependencies
+
+### Type Reference
+
+Every BUSY document has a Type. Learn what each one means:
+
+- [Core Types](./reference/core-types.busy.md) — Document, View, Model, Playbook, Config, Tool, and more
+- [Workspace Structure](./reference/workspace-structure.busy.md) — The `.workspace` config and folder conventions

--- a/docs/views/reference/core-types.busy.md
+++ b/docs/views/reference/core-types.busy.md
@@ -1,0 +1,223 @@
+---
+Name: Core Types Reference
+Type: [View]
+Description: Reference guide to all BUSY document types — Document, View, Model, Playbook, Config, Tool, Prompt, Role, Concept, and Checklist.
+---
+
+# Imports
+
+[View]:../../../busy/core/view.busy.md
+[Document]:../../../busy/core/document.busy.md
+[Model]:../../../busy/core/model.busy.md
+[Playbook]:../../../busy/core/playbook.busy.md
+[Config]:../../../busy/core/config.busy.md
+[Tool]:../../../busy/core/tool.busy.md
+[Prompt]:../../../busy/core/prompt.busy.md
+[Role]:../../../busy/core/role.busy.md
+[Concept]:../../../busy/core/concept.busy.md
+[Checklist]:../../../busy/core/checklist.busy.md
+[Operation]:../../../busy/core/operation.busy.md
+[Home]:../home.busy.md
+
+# Setup
+
+This view provides a reference of every BUSY document type, explaining when to use each one and what sections they expect.
+
+# Display
+
+## Core Types Reference
+
+Every BUSY document declares a Type in its frontmatter. The type determines what sections the document should contain and how agents interpret it.
+
+### Type Summary
+
+| Type | Purpose | Key Sections |
+|------|---------|-------------|
+| Document | General-purpose container | Setup, Operations |
+| Concept | Abstract idea or definition | Setup, Local Definitions |
+| Model | Domain entity with state | Identity, Fields, Lifecycle, Rules |
+| Config | Singleton settings object | Fields, Defaults, Rules |
+| View | Presentation layer for LORE | Data Sources, Display, Operations |
+| Playbook | Orchestrates a sequence of work | Sequence Steps, Conditions |
+| Tool | Wraps an external capability | Capability, Invocation Contract |
+| Prompt | Entry point for LLM execution | Prompt Text, Operations |
+| Role | Persona definition | Traits, Principles, Skillset |
+| Checklist | Verification sequence | Checklist items |
+| Operation | Unit of work (used as a concept) | Input, Steps, Output, Checklist |
+
+### Document
+
+The foundational type. Every other type extends Document. Use it for general-purpose documents that don't fit a more specific type.
+
+```yaml
+Type: [Document]
+```
+
+**Standard sections:** Imports, Setup, Local Definitions, Operations
+
+**When to use:** For documents that define operations and concepts but aren't models, playbooks, tools, or views.
+
+### Concept
+
+An abstract idea or abstraction that is explicitly defined and referenceable. Concepts don't have operations — they exist to be imported and referenced by other documents.
+
+```yaml
+Type: [Concept]
+```
+
+**When to use:** For shared definitions, glossary terms, or abstract ideas that multiple documents reference. The `Document` and `Operation` core types are themselves Concepts.
+
+### Model
+
+A domain entity — something that exists, has fields, and changes state over time. Think of it as a database table definition written in plain language.
+
+```yaml
+Type: [Model]
+```
+
+**Required sections:**
+- **Identity** — what makes each instance unique
+- **Fields** — table of field name, type, meaning, required
+- **Lifecycle** — valid states and transitions
+- **Rules** — constraints that must always hold
+- **Relationships** — connections to other models
+- **Persistence** — which adapter handles storage
+
+**Built-in operations:** `createInstance`, `updateInstance`, `transitionState`, `findByIdentity`, `listInstances`
+
+**Example:**
+```markdown
+## Identity
+Each customer is identified by a unique `customer_id` (UUID).
+
+## Fields
+| Field | Type | Meaning | Required |
+|-------|------|---------|----------|
+| customer_id | uuid | Unique identifier | Yes |
+| name | string | Full name | Yes |
+| email | string | Contact email | Yes |
+| status | string | Account status | Yes |
+
+## Lifecycle
+| State | Can Transition To | Trigger |
+|-------|-------------------|---------|
+| active | suspended, closed | - |
+| suspended | active, closed | - |
+| closed | - | - |
+```
+
+### Config
+
+A singleton Model — exactly one instance exists per workspace. Use for settings, feature flags, and configuration objects.
+
+```yaml
+Type: [Config]
+```
+
+**Sections:** Fields, Defaults, Rules (no Lifecycle or Relationships)
+
+**When to use:** For workspace settings where there's one authoritative record, not a collection. Think settings files, not database tables.
+
+### View
+
+A presentation document that composes data from Models and renders it for display. Views can be compiled into LORE site pages.
+
+```yaml
+Type: [View]
+```
+
+**Key sections:**
+- **Data Sources** — imported Models and Configs that provide data
+- **Display** — markdown layout with optional Handlebars placeholders
+- **Operations** — user actions (refresh, filter, navigate)
+
+**A View is renderable** if it has a Display section or imports Models. The LORE compiler picks up renderable Views and generates site pages from them.
+
+**When to use:** For dashboards, overviews, documentation pages — anything that presents information.
+
+### Playbook
+
+An orchestration document that sequences operations, prompts, tools, or roles with optional branching.
+
+```yaml
+Type: [Playbook]
+```
+
+**Key sections:**
+- **Sequence Steps** — ordered list of operations to execute
+- **Conditions** — boolean checks for branching
+- **Role Context** — optional role to assume for specific steps
+- **Private Operations** — reusable helpers prefixed with `_`
+
+**When to use:** For multi-step workflows that coordinate multiple operations, like onboarding processes or review pipelines.
+
+### Tool
+
+A wrapper around an external capability — CLI, MCP, API, or script — so agents can invoke it consistently.
+
+```yaml
+Type: [Tool]
+```
+
+**Key sections:**
+- **Capability** — what effect the tool provides
+- **Invocation Contract** — how to call the underlying resource
+- **State** — optional state management instructions
+- **Events** — events the tool can generate
+- **Providers** — maps abstract actions to provider-specific implementations
+
+**When to use:** For anything that calls external systems. Keep tools mechanical and minimal — reference scripts or prompts rather than embedding logic inline.
+
+### Prompt
+
+An entry point for LLM interaction. Defines the overall task and guides the LLM through operations.
+
+```yaml
+Type: [Prompt]
+```
+
+**Key sections:**
+- **Prompt Text** — the instruction for the LLM
+- **Operations** — `executePrompt` orchestrates the work
+
+**When to use:** For top-level documents that an LLM will directly execute.
+
+### Role
+
+A persona definition with traits, principles, and skillset. Agents adopt roles before executing certain operations.
+
+```yaml
+Type: [Role]
+```
+
+**Key sections:**
+- **Traits** — personality characteristics
+- **Principles** — guiding rules and boundaries
+- **Skillset** — capabilities the role possesses
+
+**When to use:** For defining agent personas — how they should behave, what they know, and what constraints they operate under.
+
+### Checklist
+
+A verification sequence attached to operations or used standalone. Items must be observable and evidence-based.
+
+```yaml
+Type: [Checklist]
+```
+
+**When to use:** For verification procedures — quality gates, formatting rules, deployment checklists. Each item should be something an agent can prove with evidence.
+
+### Choosing the Right Type
+
+| You want to... | Use |
+|-----------------|-----|
+| Define a domain entity with fields and state | Model |
+| Define workspace settings | Config |
+| Show information in a dashboard | View |
+| Orchestrate a multi-step workflow | Playbook |
+| Wrap an external API or CLI | Tool |
+| Give an agent a persona | Role |
+| Create an LLM task entry point | Prompt |
+| Define a verification procedure | Checklist |
+| Define a reusable abstract concept | Concept |
+| Everything else | Document |

--- a/docs/views/reference/workspace-structure.busy.md
+++ b/docs/views/reference/workspace-structure.busy.md
@@ -1,0 +1,190 @@
+---
+Name: Workspace Structure Reference
+Type: [View]
+Description: Reference for the .workspace configuration file, folder conventions, execution flow, and validation requirements.
+---
+
+# Imports
+
+[View]:../../../busy/core/view.busy.md
+[Workspace]:../../../busy/core/workspace.busy.md
+[Document]:../../../busy/core/document.busy.md
+[Home]:../home.busy.md
+
+# Setup
+
+This view documents the `.workspace` configuration schema, standard folder layout, execution flow, and validation requirements for BUSY workspaces.
+
+# Display
+
+## Workspace Structure Reference
+
+A BUSY workspace is a folder identified by a `.workspace` configuration file. It bundles everything needed for an agent to execute a task or workflow.
+
+### Standard Folder Layout
+
+```
+workspace-root/
+├── .workspace                  # Configuration (JSON)
+├── instructions.busy.md        # What to do (REQUIRED)
+├── operations.busy.md          # Operation definitions
+├── role.busy.md                # Agent persona (optional)
+├── playbook.busy.md            # Orchestration flow (optional)
+├── package.busy.md             # External dependencies
+├── .libraries/                 # Cached packages
+├── input/                      # Input files
+├── output/                     # Final deliverables
+├── .trace/                     # Execution trace logs
+├── trace.log                   # Main log file
+└── memory.json                 # Agent memory/state
+```
+
+**File extension rules:**
+- All BUSY documents **must** use `.busy.md` — the parser ignores plain `.md`
+- Agent state files (`CLAUDE.md`, `GEMINI.md`, `AGENT.md`) use plain `.md`
+- General files (`trace.log`, `memory.json`) use standard extensions
+
+### .workspace Configuration
+
+The `.workspace` file is JSON:
+
+```json
+{
+  "name": "my-workspace",
+  "type": "workspace",
+  "version": "1.0",
+  "framework": "claude",
+  "hasRole": true,
+  "hasSteps": false,
+  "inputSource": "input",
+  "outputDestination": "output"
+}
+```
+
+**Required fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Workspace name |
+| `type` | string | Always `"workspace"` |
+| `version` | string | Configuration version (e.g., `"1.0"`) |
+| `framework` | string | Agent framework (`"claude"`, `"openai"`, etc.) |
+
+**Optional fields:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `hasRole` | boolean | false | Whether `role.busy.md` exists |
+| `hasSteps` | boolean | false | Whether multi-step playbook |
+| `inputSource` | string | `"input"` | Input directory name |
+| `outputDestination` | string | `"output"` | Output directory name |
+| `nestedWorkspaces` | array | [] | Sub-workspace paths and commands |
+| `validationCache` | object | null | Cached validation results |
+
+### Content Ownership
+
+Each file has a clear purpose — don't mix responsibilities:
+
+| File | Owns | Does NOT Own |
+|------|------|-------------|
+| `instructions.busy.md` | Navigation hub, prerequisites, pointers | Operation logic |
+| `operations.busy.md` | Full operation definitions, inputs, outputs | Persona, flow control |
+| `role.busy.md` | Persona, traits, principles, skillset | Operations, instructions |
+| `playbook.busy.md` | Execution flow, sequencing, error handling | Individual operation logic |
+
+### Multi-Step Workspaces
+
+For sequential workflows, create step folders:
+
+```
+workspace/
+├── .workspace
+├── instructions.busy.md
+├── step-1-review/
+│   ├── .workspace
+│   ├── instructions.busy.md
+│   ├── input/
+│   ├── output/
+│   └── deliverable.md
+├── step-2-draft/
+│   ├── .workspace
+│   ├── instructions.busy.md
+│   ├── input/
+│   ├── output/
+│   └── deliverable.md
+└── output/
+```
+
+**Naming convention:** `step-<number>-<name>/` (e.g., `step-1-review-requirements/`)
+
+**Input/output chain:**
+1. First step → reads from parent `input/`
+2. Middle steps → reads from previous step's `deliverable.md`
+3. Last step → writes to parent `output/`
+
+### Nested Workspaces
+
+Any folder with a `.workspace` file is an independent sub-workspace:
+
+```
+parent/
+├── .workspace
+├── instructions.busy.md
+└── child-workspace/
+    ├── .workspace
+    ├── instructions.busy.md
+    └── grandchild/
+        ├── .workspace
+        └── instructions.busy.md
+```
+
+**Invocation:** The parent calls nested workspaces using the configured command:
+```bash
+cd child-workspace
+claude -p "execute your instructions"
+```
+
+**Execution is synchronous by default** — the parent waits for each nested workspace to complete.
+
+### Execution Flow
+
+When an agent executes a workspace:
+
+1. **Detect** — Check for `.workspace` file
+2. **Load** — Parse `.workspace` JSON
+3. **Assume Role** — If `hasRole: true`, read and adopt `role.busy.md`
+4. **Execute** — Read `instructions.busy.md` and follow them
+5. **Handle Steps** — If `hasSteps: true`, execute step folders in order
+6. **Invoke Nested** — For sub-workspaces, execute their commands
+7. **Write Output** — Place deliverables in `output/`
+
+### Validation Requirements
+
+A valid workspace must satisfy all of these:
+
+| Requirement | Check |
+|-------------|-------|
+| `.workspace` exists | Valid JSON with required fields |
+| `instructions.busy.md` exists | Has `.busy.md` extension and valid BUSY format |
+| Standard directories | `input/`, `output/`, `.trace/` exist |
+| Role file (if declared) | `role.busy.md` exists when `hasRole: true` |
+| Operations file (if present) | `operations.busy.md` has valid BUSY format |
+| Playbook file (if present) | `playbook.busy.md` has valid BUSY format |
+| Step folders (if declared) | Each step has proper workspace structure |
+| Nested workspaces | Each declared sub-workspace is itself valid |
+| Working files | `trace.log` and `memory.json` initialized |
+
+Use `busy check` to validate workspace coherence, and `busy validate` to check individual files.
+
+### Trace Logging
+
+All workspace execution should be logged to `trace.log`:
+
+```
+2026-03-20T14:30:00Z | Workspace -> ReviewRequirements | Starting requirements review.
+2026-03-20T14:30:15Z | Workspace -> ReviewRequirements | Completed. 3 requirements validated.
+```
+
+Format: `timestamp | Document -> Operation | message`
+
+This creates an audit trail that humans and downstream tools can inspect.


### PR DESCRIPTION
## Summary

Add 10 BUSY View documents under `docs/views/` that can be compiled into a navigable LORE site, providing guidance on authoring BUSY files, structuring workspaces, and using the CLI.

## Changes

### New Files (10 View documents)

**Home:**
- `docs/views/home.busy.md` — Site entry point with navigation to all sections

**Guides (3):**
- `docs/views/guides/document-authoring.busy.md` — How to write `.busy.md` files (frontmatter, imports, sections, operations, checklists)
- `docs/views/guides/imports-and-linking.busy.md` — Import syntax, path resolution, anchor references, edge types
- `docs/views/guides/workspace-setup.busy.md` — Init, layout, packages, `.workspace` config, validation

**CLI Reference (4):**
- `docs/views/cli/overview.busy.md` — All commands at a glance
- `docs/views/cli/validate.busy.md` — `busy validate` usage, options, error patterns
- `docs/views/cli/graph.busy.md` — `busy graph` formats (JSON, tree, DOT), filtering, statistics
- `docs/views/cli/workspace-commands.busy.md` — `busy init`, `busy check`, `busy package` subcommands

**Reference (2):**
- `docs/views/reference/core-types.busy.md` — Document, View, Model, Playbook, Config, Tool, Prompt, Role, Concept, Checklist
- `docs/views/reference/workspace-structure.busy.md` — `.workspace` schema, folder conventions, execution flow, validation

## LORE Compilation

These views can be compiled into a LORE site via:
```typescript
await mountBusyWorkspace(host, {
  workspaceRoot: 'docs/views',
  globs: ['docs/views/**/*.busy.md'],
  compiler: { navigation: { homePageId: 'home' } },
});
```

## Test Results

### Validation
```
All 10 documents pass `busy validate` ✓
All imports resolve correctly with --resolve-imports ✓
```

### Graph
```
views (10 documents, 26 edges)
├── cli/ (4 docs)
│   ├── [View] Graph Command (3 importers, 2 imports)
│   ├── [View] CLI Overview (4 importers, 7 imports)
│   ├── [View] Validate Command (3 importers, 2 imports)
│   └── [View] Workspace Commands (2 importers, 2 imports)
├── guides/ (3 docs)
│   ├── [View] Document Authoring Guide (1 importers, 1 imports)
│   ├── [View] Imports and Linking Guide (1 importers, 1 imports)
│   └── [View] Workspace Setup Guide (1 importers, 1 imports)
├── reference/ (2 docs)
│   ├── [View] Core Types Reference (1 importers, 1 imports)
│   └── [View] Workspace Structure Reference (1 importers, 1 imports)
└── [View] BUSY Documentation (9 importers, 8 imports)
```

### Unit Tests
```
Test Files  13 passed (13)
     Tests  329 passed (329)
  Duration  322ms
```

## Acceptance Criteria Verification
- [x] AC1: 10 View documents exist (1 home + 3 guides + 4 CLI + 2 reference)
- [x] AC2: All pass `busy validate`, imports resolve correctly
- [x] AC3: `busy graph --format tree` shows valid 10-node graph with 26 edges
- [x] AC4: Content covers authoring, CLI commands, core types with practical examples

PFM-110