### PR TITLE
chore(busy-cli): point exports at src/ for git installs

### DIFF
--- a/packages/busy-cli/package.json
+++ b/packages/busy-cli/package.json
@@ -3,15 +3,16 @@
   "version": "0.3.1",
   "description": "CLI for BUSY document framework - parse, validate, and manage BUSY workspaces",
   "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "bin": {
     "busy": "./dist/cli/index.js"
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
Git-based installs don't build, so dist/ doesn't exist. Point exports at src/ TypeScript files so consumers using tsx/jiti can import directly. Same pattern already used by lore-core. All 329 tests pass.