### PR TITLE
chore(busy-cli): bump to 0.4.0, restore dist exports for npm publish

### DIFF
--- a/packages/busy-cli/package.json
+++ b/packages/busy-cli/package.json
@@ -1,20 +1,24 @@
 {
   "name": "busy-cli",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "CLI for BUSY document framework - parse, validate, and manage BUSY workspaces",
   "type": "module",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "bin": {
     "busy": "./dist/cli/index.js"
   },
   "exports": {
     ".": {
-      "types": "./src/index.ts",
-      "import": "./src/index.ts",
-      "default": "./src/index.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
+  "files": [
+    "dist",
+    "src"
+  ],
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",


### PR DESCRIPTION
Prepares busy-cli for npm publish as part of PFM-111.

**Changes:**
- Bump 0.3.1 → 0.4.0
- Restore `main`/`exports` to point at `dist/` (correct for npm consumers)
- Add `files` to include both `dist/` and `src/` in tarball (so tsx/jiti git installs still work)

**What's new since 0.3.1:**
- Generic `meta` passthrough in frontmatter schema (needed by lore-core for `Lore.Route` / `Lore.Permission`)
- `busy graph` CLI command
- Self-cycle suppression in graph warnings

329 tests pass.

PFM-111