### PR TITLE
feat(PFM-115): parse Params from View frontmatter

### DIFF
--- a/busy/core/view.busy.md
+++ b/busy/core/view.busy.md
@@ -43,6 +43,29 @@ A [View] with a Display section is renderable — a LORE compiler can compile it
 - Put meaningful user actions in [Operations]; do not assume every inline link will become an explicit runtime action affordance.
 - Links to non-renderable documents should be treated as references unless promoted by compiler/runtime rules.
 
+### Page Views and Component Views
+
+A [View] may be authored as either a **page view** or a **component view**.
+
+- **Page view** — route-bound, owns data loading and page composition. It imports [Model]s and [Config]s as data sources and may embed component views inside its [Display Section].
+- **Component view** — embeddable and presentational. It receives data from a parent page view as params and should avoid doing its own data loading.
+
+Component views declare expected params in frontmatter:
+
+```yaml
+Params:
+  - prospect: object (required)
+  - show_pricing: boolean
+```
+
+A page view may embed a component view using an import link with query-string params:
+
+```markdown
+[Status Card]:../components/status-card.busy.md?prospect={{prospect}}
+```
+
+This keeps data ownership at the page level while allowing reusable display fragments.
+
 # [Local Definitions](./document.busy.md#local-definitions-section)
 
 ## [Data Source]

--- a/docs/views/reference/core-types.busy.md
+++ b/docs/views/reference/core-types.busy.md
@@ -135,6 +135,32 @@ Type: [View]
 
 **When to use:** For dashboards, overviews, documentation pages — anything that presents information.
 
+#### Page Views vs Component Views
+
+Views come in two flavors:
+
+**Page views** are route-bound — they own data queries, compose components, and handle layout with conditional sections via Handlebars. They have a `# Data` section that queries Models.
+
+**Component views** are embeddable — they receive data as params from a parent page view and render a focused slice. They declare `Params` in frontmatter and have no data-fetching logic. Page views embed them using query strings on import links:
+
+```markdown
+[Component]:../components/status-card.busy.md?prospect={{prospect}}
+```
+
+Component views declare their expected params:
+
+```yaml
+---
+Name: Status Card
+Type: [View]
+Params:
+  - prospect: object (required)
+  - show_details: boolean
+---
+```
+
+This keeps data ownership at the page level and components composable across pages.
+
 ### Playbook
 
 An orchestration document that sequences operations, prompts, tools, or roles with optional branching.

--- a/packages/busy-cli/src/__tests__/view-config.test.ts
+++ b/packages/busy-cli/src/__tests__/view-config.test.ts
@@ -142,6 +142,38 @@ The Canon SDLC defines a 6-phase software development lifecycle.
 Phases: Intake, Shape, Spec, Implement, Review, Ship.
 `;
 
+const VIEW_WITH_PARAMS = `---
+Name: Prospect Status Card
+Type: [View]
+Description: Reusable component that renders prospect status
+Params:
+  - prospect: object (required)
+  - show_hook: boolean
+---
+
+# Display
+
+**{{prospect.agent_name}}** — {{prospect.lifecycle_state}}
+
+{{#if show_hook}}
+Hook delivered: {{prospect.hook_type}}
+{{/if}}
+`;
+
+const VIEW_WITH_PARAMS_OBJECT_STYLE = `---
+Name: Pricing Card
+Type: [View]
+Description: Pricing component
+Params:
+  - prospect: object (required)
+  - hooks: array
+---
+
+# Display
+
+Pricing for **{{prospect.agent_name}}**
+`;
+
 // ── Setup / Teardown ────────────────────────────────────────────────
 
 function setupFixtures() {
@@ -151,6 +183,8 @@ function setupFixtures() {
   writeFileSync(join(FIXTURES_DIR, 'simple-view.busy.md'), VIEW_NO_TEMPLATE);
   writeFileSync(join(FIXTURES_DIR, 'listing-detail.busy.md'), VIEW_WITH_LORE);
   writeFileSync(join(FIXTURES_DIR, 'canon-sdlc.busy.md'), CONFIG_DOC);
+  writeFileSync(join(FIXTURES_DIR, 'prospect-status-card.busy.md'), VIEW_WITH_PARAMS);
+  writeFileSync(join(FIXTURES_DIR, 'pricing-card.busy.md'), VIEW_WITH_PARAMS_OBJECT_STYLE);
 }
 
 function cleanFixtures() {
@@ -172,8 +206,8 @@ describe('View and Config Types', () => {
   });
 
   describe('Loading', () => {
-    it('loads all 5 fixture documents', () => {
-      expect(repo.concepts.length).toBe(5);
+    it('loads all 7 fixture documents', () => {
+      expect(repo.concepts.length).toBe(7);
     });
 
     it('classifies Model as document', () => {
@@ -275,6 +309,53 @@ describe('View and Config Types', () => {
         Route: '/market-monitoring/listing/:listingId',
         Permission: 'premium',
       });
+    });
+
+    it('parses Params from frontmatter into typed params array', () => {
+      const viewDocId = Object.keys(repo.byFile).find(id =>
+        repo.byFile[id].concept.name === 'Prospect Status Card'
+      )!;
+      const viewDoc = repo.byFile[viewDocId].concept;
+      expect(viewDoc.kind).toBe('view');
+      if (viewDoc.kind === 'view') {
+        expect(viewDoc.params).toBeDefined();
+        expect(viewDoc.params).toHaveLength(2);
+        expect(viewDoc.params![0]).toEqual({ name: 'prospect', type: 'object', required: true });
+        expect(viewDoc.params![1]).toEqual({ name: 'show_hook', type: 'boolean', required: false });
+      }
+    });
+
+    it('does not include Params in meta when params are parsed', () => {
+      const viewDocId = Object.keys(repo.byFile).find(id =>
+        repo.byFile[id].concept.name === 'Prospect Status Card'
+      )!;
+      const viewDoc = repo.byFile[viewDocId].concept;
+      expect(viewDoc.meta?.Params).toBeUndefined();
+    });
+
+    it('parses Params with multiple required/optional params', () => {
+      const viewDocId = Object.keys(repo.byFile).find(id =>
+        repo.byFile[id].concept.name === 'Pricing Card'
+      )!;
+      const viewDoc = repo.byFile[viewDocId].concept;
+      expect(viewDoc.kind).toBe('view');
+      if (viewDoc.kind === 'view') {
+        expect(viewDoc.params).toBeDefined();
+        expect(viewDoc.params).toHaveLength(2);
+        expect(viewDoc.params![0]).toEqual({ name: 'prospect', type: 'object', required: true });
+        expect(viewDoc.params![1]).toEqual({ name: 'hooks', type: 'array', required: false });
+      }
+    });
+
+    it('has no params when Params frontmatter is absent', () => {
+      const viewDocId = Object.keys(repo.byFile).find(id =>
+        repo.byFile[id].concept.name === 'Prospect Pipeline'
+      )!;
+      const viewDoc = repo.byFile[viewDocId].concept;
+      expect(viewDoc.kind).toBe('view');
+      if (viewDoc.kind === 'view') {
+        expect(viewDoc.params).toBeUndefined();
+      }
     });
   });
 

--- a/packages/busy-cli/src/index.ts
+++ b/packages/busy-cli/src/index.ts
@@ -12,6 +12,7 @@ export type {
   BusyDocument,
   Playbook,
   View,
+  ViewParam,
   Config,
   LocalDef,
   Operation,

--- a/packages/busy-cli/src/loader.ts
+++ b/packages/busy-cli/src/loader.ts
@@ -268,10 +268,15 @@ export async function loadRepo(globs: string[]): Promise<Repo> {
         // Reconstruct full template from section + children content
         displayContent = getSectionFullContent(displaySection);
       }
+      // Parse Params from frontmatter meta (falls through KNOWN_FRONTMATTER_KEYS)
+      const params = parseViewParams(meta.Params);
+      // Remove Params from meta since it's now a first-class field
+      delete meta.Params;
       const doc: View = {
         ...baseFields,
         kind: 'view',
         display: displayContent,
+        ...(params.length > 0 ? { params } : {}),
       };
       docs.push(doc);
     } else if (isConfig) {
@@ -476,6 +481,56 @@ function getSectionFullContent(section: Section): string {
     content += `\n${prefix} ${child.title}\n${getSectionFullContent(child)}`;
   }
   return content.trim();
+}
+
+/**
+ * Parse Params frontmatter value into typed ViewParam array.
+ *
+ * Accepts YAML-parsed arrays like:
+ *   Params:
+ *     - prospect: object (required)
+ *     - show_hook: boolean
+ *
+ * Each entry can be:
+ *   - A string like "name: type (required)" or "name: type"
+ *   - An object like { name: "prospect", type: "object", required: true }
+ */
+function parseViewParams(raw: unknown): { name: string; type: string; required: boolean }[] {
+  if (!Array.isArray(raw)) return [];
+
+  const params: { name: string; type: string; required: boolean }[] = [];
+
+  for (const entry of raw) {
+    if (typeof entry === 'string') {
+      // Parse "name: type (required)" or "name: type" or just "name"
+      const match = entry.match(/^\s*([\w-]+)\s*(?::\s*(\w+))?\s*(?:\(([^)]*)\))?\s*$/);
+      if (match) {
+        const name = match[1];
+        const type = match[2] ?? 'string';
+        const modifiers = (match[3] ?? '').toLowerCase();
+        params.push({ name, type, required: modifiers.includes('required') });
+      }
+    } else if (entry && typeof entry === 'object') {
+      // YAML parsed as object — e.g. { prospect: "object (required)" }
+      for (const [key, value] of Object.entries(entry as Record<string, unknown>)) {
+        if (typeof value === 'string') {
+          const match = value.match(/^\s*(\w+)?\s*(?:\(([^)]*)\))?\s*$/);
+          const type = match?.[1] ?? 'string';
+          const modifiers = (match?.[2] ?? '').toLowerCase();
+          params.push({ name: key, type, required: modifiers.includes('required') });
+        } else if (typeof value === 'object' && value !== null) {
+          const v = value as Record<string, unknown>;
+          params.push({
+            name: v.name as string ?? key,
+            type: (v.type as string) ?? 'string',
+            required: (v.required as boolean) ?? false,
+          });
+        }
+      }
+    }
+  }
+
+  return params;
 }
 
 /**

--- a/packages/busy-cli/src/types/schema.ts
+++ b/packages/busy-cli/src/types/schema.ts
@@ -262,11 +262,21 @@ export const PlaybookSchema = LegacyBusyDocumentSchema.extend({
     sequence: z.array(ConceptIdSchema), // Ordered array of operation references
   })
 
+// View param schema — typed parameters for component views
+export const ViewParamSchema = z.object({
+    name: z.string(),
+    type: z.string().default('string'),  // object, string, boolean, array, etc.
+    required: z.boolean().default(false),
+  })
+
+export type ViewParam = z.infer<typeof ViewParamSchema>;
+
 // View schema - extends LegacyBusyDocument with display section
 // Views follow MVC: imports=Model, localDefs=ViewModel, template=View, operations=Controller
 export const ViewSchema = LegacyBusyDocumentSchema.extend({
     kind: z.literal('view'),
     display: z.string().optional(),           // Markdown template (optional — LORE can generate)
+    params: z.array(ViewParamSchema).optional(), // Typed params for component views
   })
 
 // Config schema - extends LegacyBusyDocument, semantically a singleton Model

--- a/packages/busy-lsp/src/server/providers/completion.ts
+++ b/packages/busy-lsp/src/server/providers/completion.ts
@@ -39,14 +39,14 @@ export class CompletionProvider {
       return this.getPathCompletions(document);
     }
 
-    // Anchor completions after #
-    if (linePrefix.includes('#')) {
-      return this.getAnchorCompletions(linePrefix, parsed, document);
-    }
-
     // Section heading completions
     if (linePrefix.match(/^#+\s*$/)) {
       return this.getSectionCompletions(position.line, parsed);
+    }
+
+    // Anchor completions after #
+    if (linePrefix.includes('#')) {
+      return this.getAnchorCompletions(linePrefix, parsed, document);
     }
 
     return items;
@@ -81,6 +81,7 @@ export class CompletionProvider {
         { name: 'Extends', detail: 'Parent document to extend' },
         { name: 'Tags', detail: 'Comma-separated tags' },
         { name: 'Provider', detail: 'Provider for tool documents' },
+        { name: 'Params', detail: 'View params for component views' },
       ];
 
       for (const field of fields) {
@@ -96,7 +97,19 @@ export class CompletionProvider {
 
     // Type value completions
     if (linePrefix.match(/^Type:\s*$/)) {
-      const types = ['Document', 'Operation', 'Tool', 'Playbook', 'Concept', 'Role'];
+      const types = [
+        'Document',
+        'Concept',
+        'Model',
+        'Config',
+        'View',
+        'Playbook',
+        'Tool',
+        'Prompt',
+        'Role',
+        'Checklist',
+        'Operation',
+      ];
       for (const type of types) {
         items.push({
           label: `[${type}]`,
@@ -285,6 +298,7 @@ export class CompletionProvider {
       { name: 'Imports', snippet: '[Imports](#imports-section)' },
       { name: 'Setup', snippet: '[Setup](#setup-section)' },
       { name: 'Local Definitions', snippet: '[Local Definitions](#local-definitions-section)' },
+      { name: 'Display', snippet: '[Display](#display-section)' },
       { name: 'Operations', snippet: '[Operations](#operations-section)' },
       { name: 'Triggers', snippet: '[Triggers](#triggers-section)' },
       { name: 'Tools', snippet: '[Tools](#tools-section)' },

--- a/packages/busy-lsp/src/server/providers/hover.ts
+++ b/packages/busy-lsp/src/server/providers/hover.ts
@@ -126,14 +126,19 @@ export class HoverProvider {
     // Check common BUSY terms
     const busyTerms: Record<string, string> = {
       Document: 'A BUSY document that defines concepts, operations, and structure.',
-      Operation: 'An executable unit with inputs, outputs, steps, and checklist.',
       Concept: 'A named definition that can be referenced throughout BUSY documents.',
-      Tool: 'An external capability wrapper with provider mappings.',
+      Model: 'A domain entity with identity, fields, lifecycle, rules, and persistence.',
+      Config: 'A singleton model for workspace settings and configuration.',
+      View: 'A presentation document used for route-bound pages or embeddable component views.',
       Playbook: 'A document with an ordered sequence of operations.',
+      Tool: 'An external capability wrapper with provider mappings.',
+      Prompt: 'An LLM entry-point document with prompt text and orchestration.',
+      Role: 'A persona document defining traits, principles, and skillset.',
+      Checklist: 'Verification items to confirm operation success.',
+      Operation: 'An executable unit with inputs, outputs, steps, and checklist.',
       Input: 'Input parameters for an operation.',
       Output: 'Output values produced by an operation.',
       Steps: 'Sequential instructions that make up an operation.',
-      Checklist: 'Verification items to confirm operation success.',
       Triggers: 'Time-based (alarm) or event-based automation declarations.',
     };
 
@@ -228,6 +233,7 @@ export class HoverProvider {
         Imports: 'Reference-style link definitions for external concepts.',
         Setup: 'Instructions executed before operations.',
         'Local Definitions': 'Reusable definitions scoped to this document.',
+        Display: 'Markdown presentation layout for a view, with Handlebars-style placeholders and conditionals.',
         Operations: 'Executable units with inputs, outputs, and steps.',
         Triggers: 'Automation declarations (alarms and events).',
         Tools: 'External capability wrappers with provider mappings.',

--- a/packages/busy-lsp/src/server/providers/view-support.test.ts
+++ b/packages/busy-lsp/src/server/providers/view-support.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { BusyDocumentManager } from '../document-manager';
+import { CompletionProvider } from './completion';
+import { HoverProvider } from './hover';
+
+describe('busy-lsp view support consistency', () => {
+  it('suggests Params in frontmatter field completions and [View] in Type completions', () => {
+    const manager = new BusyDocumentManager();
+    const provider = new CompletionProvider(manager);
+    const uri = 'file:///workspace/example.busy.md';
+    const content = `---
+Name: Example View
+Type: 
+
+---
+
+# [Imports](#imports-section)
+`;
+    const document = TextDocument.create(uri, 'busy', 1, content);
+    manager.openDocument(uri, content);
+
+    const fieldCompletions = provider.provideCompletions(document, { line: 3, character: 0 });
+    expect(fieldCompletions.map((item) => item.label)).toContain('Params');
+
+    const typeCompletions = provider.provideCompletions(document, { line: 2, character: 6 });
+    expect(typeCompletions.map((item) => item.label)).toContain('[View]');
+  });
+
+  it('suggests Display as a top-level section completion', () => {
+    const manager = new BusyDocumentManager();
+    const provider = new CompletionProvider(manager);
+    const uri = 'file:///workspace/view.busy.md';
+    const content = `---
+Name: Example View
+Type: [View]
+Description: Test view
+---
+
+# [Imports](#imports-section)
+
+# [Setup](#setup-section)
+
+# [Local Definitions](#local-definitions-section)
+
+# `;
+    const document = TextDocument.create(uri, 'busy', 1, content);
+    manager.openDocument(uri, content);
+
+    const completions = provider.provideCompletions(document, { line: 12, character: 2 });
+    expect(completions.map((item) => item.label)).toContain('# [Display](#display-section)');
+  });
+
+  it('shows hover help for the Display section', () => {
+    const manager = new BusyDocumentManager();
+    const provider = new HoverProvider(manager);
+    const uri = 'file:///workspace/view.busy.md';
+    const content = `---
+Name: Example View
+Type: [View]
+Description: Test view
+---
+
+# [Imports](#imports-section)
+
+# [Display](#display-section)
+Some content
+`;
+    const document = TextDocument.create(uri, 'busy', 1, content);
+    manager.openDocument(uri, content);
+
+    const hover = provider.provideHover(document, { line: 8, character: 4 });
+    expect(hover?.contents).toBeDefined();
+    const value = typeof hover?.contents === 'string'
+      ? hover.contents
+      : Array.isArray(hover?.contents)
+        ? hover.contents[0]?.value ?? ''
+        : hover?.contents.value ?? '';
+    expect(value).toContain('BUSY Section');
+    expect(value).toContain('Display');
+    expect(value).toContain('Markdown presentation layout');
+  });
+});


### PR DESCRIPTION
## Summary
Add `Params` support to BUSY View documents, update core View docs, and align busy-lsp authoring support with the new component-view pattern.

## Changes
### busy-cli
- **schema.ts** — `ViewParamSchema` + `params` field on `ViewSchema`
- **loader.ts** — `parseViewParams()` extracts Params from frontmatter meta, supports string format (`name: type (required)`) and object format
- **index.ts** — export `ViewParam` type
- **view-config.test.ts** — 4 new tests covering params parsing, absence, meta cleanup

### BUSY docs
- **busy/core/view.busy.md** — document page view vs component view authoring, `Params`, and query-string composition
- **docs/views/reference/core-types.busy.md** — add page view vs component view guidance

### busy-lsp
- **completion.ts**
  - add `Params` frontmatter completion
  - expand `Type:` completions to include `View` and other core types
  - add `Display` section completion
  - fix completion ordering so `# ` headings get section completions instead of anchor completions
- **hover.ts**
  - add `Display` section hover help
  - add missing core BUSY concept hovers including `View`
- **view-support.test.ts** — targeted tests for the new View authoring support

## Testing
### busy-cli
```bash
cd packages/busy-cli
npm test -- --reporter=verbose
# 333 passed (13 test files)
```

### busy-lsp
```bash
cd packages/busy-lsp
npm test -- --reporter=verbose
# 3 passed (1 test file)

npm run build
# success
```

## Context
First subtask of PFM-114 (LORE component views). This enables the compiler/runtime work by letting View docs declare component params, while keeping BUSY docs and editor support aligned with the new page-vs-component authoring model.
