### PR TITLE
chore(release): bump busy-cli to 0.5.0 and busy-lsp to 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4728,7 +4728,7 @@
       }
     },
     "packages/busy-cli": {
-      "version": "0.3.1",
+      "version": "0.5.0",
       "license": "ISC",
       "dependencies": {
         "commander": "^12.1.0",
@@ -5091,7 +5091,7 @@
       }
     },
     "packages/busy-lsp": {
-      "version": "0.1.18",
+      "version": "0.2.0",
       "license": "ISC",
       "dependencies": {
         "vscode-languageclient": "^9.0.1",

--- a/packages/busy-cli/package-lock.json
+++ b/packages/busy-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@busy/parser",
-  "version": "0.3.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@busy/parser",
-      "version": "0.3.1",
+      "version": "0.5.0",
       "license": "ISC",
       "dependencies": {
         "commander": "^12.1.0",

--- a/packages/busy-cli/package.json
+++ b/packages/busy-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "busy-cli",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "CLI for BUSY document framework - parse, validate, and manage BUSY workspaces",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/busy-lsp/package-lock.json
+++ b/packages/busy-lsp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "busy-lsp",
-  "version": "0.1.18",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "busy-lsp",
-      "version": "0.1.18",
+      "version": "0.2.0",
       "license": "ISC",
       "dependencies": {
         "vscode-languageclient": "^9.0.1",

--- a/packages/busy-lsp/package.json
+++ b/packages/busy-lsp/package.json
@@ -2,7 +2,7 @@
   "name": "busy-lsp",
   "displayName": "BUSY Language Support",
   "description": "Language server and VS Code extension for BUSY markdown documents",
-  "version": "0.1.18",
+  "version": "0.2.0",
   "publisher": "busy-lang",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
Minor release bump for the merged View/component-view work.

## Version bumps
- `busy-cli`: `0.4.0` → `0.5.0`
- `busy-lsp`: `0.1.18` → `0.2.0`

## Why minor
The merged work added new user-facing capability rather than a patch-only fix:
- `busy-cli` now parses `Params` from `View` frontmatter
- `busy-lsp` now supports `Params`, `Display` section authoring help, and improved `View` completions/hovers
- BUSY docs now define page views vs component views

## Validation
### busy-cli
```bash
cd packages/busy-cli
npm test -- --reporter=verbose
# 333 passed
```

### busy-lsp
```bash
cd packages/busy-lsp
npm test -- --reporter=verbose
# 3 passed

npm run build
# success
```

### Publish guard
Checked that the target versions are not already published:
- `busy-cli@0.5.0` — not found on npm
- `busy-lsp@0.2.0` — not found on npm

## Release plan
After merge:
1. tag `cli-v0.5.0`
2. tag `lsp-v0.2.0`
3. push both tags to trigger `.github/workflows/publish.yml`
