### PR TITLE
feat(busy-cli): export workspace automation IR

### DIFF
--- a/docs/views/cli/overview.busy.md
+++ b/docs/views/cli/overview.busy.md
@@ -1,7 +1,7 @@
 ---
 Name: CLI Overview
 Type: [View]
-Description: Overview of all available busy CLI commands — parse, validate, resolve, graph, init, check, and package management.
+Description: Overview of all available busy CLI commands — parse, validate, resolve, automation IR export, graph, init, check, and package management.
 ---
 
 # Imports
@@ -35,6 +35,7 @@ npm install -g @busy/parser
 | `busy validate <file>` | Validate a document's frontmatter, structure, and imports |
 | `busy resolve <file>` | Resolve all imports in a document recursively |
 | `busy graph [directory]` | Output the workspace dependency graph |
+| `busy automation-ir [directory]` | Output machine-consumable workspace automation IR |
 | `busy info <file>` | Show quick document information |
 | `busy init` | Initialize a new workspace with `package.busy.md` |
 | `busy check` | Validate workspace coherence (packages, links, integrity) |
@@ -93,11 +94,18 @@ busy check
 busy check -d ./my-workspace
 ```
 
-**Graph** — Visualize the full workspace:
+**Graph** — Visualize the full workspace dependency topology:
 ```bash
 busy graph --format tree
 busy graph --format dot > workspace.dot
 busy graph --filter Model
+```
+
+**Automation IR** — Export runtime-oriented workspace data for consumers like LORE or pi-bus:
+```bash
+busy automation-ir
+busy automation-ir --include-graph
+busy automation-ir -o workspace-ir.json
 ```
 
 For detailed usage, see [Workspace Commands](./workspace-commands.busy.md).

--- a/docs/views/cli/workspace-commands.busy.md
+++ b/docs/views/cli/workspace-commands.busy.md
@@ -1,7 +1,7 @@
 ---
 Name: Workspace Commands
 Type: [View]
-Description: How to use busy init, busy check, and busy package commands to manage workspaces and dependencies.
+Description: How to use busy init, busy check, busy automation-ir, and busy package commands to manage workspaces and dependencies.
 ---
 
 # Imports
@@ -14,7 +14,7 @@ Description: How to use busy init, busy check, and busy package commands to mana
 
 # Setup
 
-This view covers the workspace-level CLI commands: `busy init`, `busy check`, and the `busy package` subcommands.
+This view covers the workspace-level CLI commands: `busy init`, `busy check`, `busy automation-ir`, and the `busy package` subcommands.
 
 # Display
 
@@ -79,6 +79,24 @@ Errors:
 
 ✗ Workspace has errors
 ```
+
+### busy automation-ir
+
+Export machine-consumable workspace automation IR built from the richer BUSY document parser:
+
+```bash
+busy automation-ir
+busy automation-ir --include-graph
+busy automation-ir -o workspace-ir.json
+```
+
+**What it includes:**
+- workspace root/name and summary stats
+- every parsed BUSY document in the workspace
+- per-document metadata, imports, operations, triggers, and tools/provider mappings when present
+- optional dependency graph summary when `--include-graph` is passed
+
+Use this when runtime consumers need a stable automation-oriented view of the workspace rather than the dependency-only output from `busy graph`.
 
 ### busy package add
 
@@ -185,5 +203,6 @@ Package: busy-v2
 2. **Add dependencies:** `busy package add` for external packages you need
 3. **Author documents:** Create `.busy.md` files that import from `.libraries/`
 4. **Check integrity:** `busy check` to verify nothing is broken
-5. **Inspect structure:** `busy graph --format tree` to see the full graph
-6. **Keep updated:** `busy package upgrade --all` periodically
+5. **Inspect structure:** `busy graph --format tree` to see the dependency graph
+6. **Export runtime IR when needed:** `busy automation-ir -o workspace-ir.json`
+7. **Keep updated:** `busy package upgrade --all` periodically

--- a/packages/busy-cli/src/__tests__/automation-ir.test.ts
+++ b/packages/busy-cli/src/__tests__/automation-ir.test.ts
@@ -1,0 +1,143 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { loadWorkspaceAutomationIR } from '../commands/automation-ir.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURES_DIR = join(__dirname, '__fixtures__', 'automation-ir');
+
+const GENERIC_DOC = `---
+Name: Lead Intake
+Type: [Document]
+Description: Processes inbound lead events.
+Triggers:
+  - event_type: gmail.message.received
+    operation: ProcessIncomingLead
+---
+
+# Operations
+
+## ProcessIncomingLead
+
+### Inputs
+- message
+
+### Steps
+1. Validate [LeadRecord]
+2. Queue [RespondToLead]
+`;
+
+const TOOL_DOC = `---
+Name: Gmail Tool
+Type: [Tool]
+Description: Gmail helper tool definitions.
+Provider: composio
+Triggers:
+  - event_type: gmail.message.received
+    operation: RouteInboundMessage
+---
+
+# Operations
+
+## RouteInboundMessage
+
+### Steps
+1. Call [send_email]
+
+# Tools
+
+## send_email
+Send an email.
+
+### Inputs
+- to
+- subject
+
+### Outputs
+- message_id
+
+### Providers
+#### composio
+Action: GMAIL_SEND_EMAIL
+Parameters:
+  to: to
+  subject: subject
+`;
+
+const PLAYBOOK_DOC = `---
+Name: Daily Digest
+Type: [Playbook]
+Description: Sends a daily digest.
+Triggers:
+  - schedule: "0 6 * * *"
+    operation: DailyReport
+---
+
+# Imports
+[Lead Intake]:./lead-intake.busy.md
+
+# Operations
+
+## DailyReport
+
+### Steps
+1. Summarize yesterday
+`;
+
+function setupFixtures() {
+  mkdirSync(FIXTURES_DIR, { recursive: true });
+  writeFileSync(join(FIXTURES_DIR, 'lead-intake.busy.md'), GENERIC_DOC);
+  writeFileSync(join(FIXTURES_DIR, 'gmail-tool.busy.md'), TOOL_DOC);
+  writeFileSync(join(FIXTURES_DIR, 'daily-digest.busy.md'), PLAYBOOK_DOC);
+}
+
+function cleanFixtures() {
+  rmSync(FIXTURES_DIR, { recursive: true, force: true });
+}
+
+describe('loadWorkspaceAutomationIR', () => {
+  beforeAll(() => {
+    setupFixtures();
+  });
+
+  afterAll(() => {
+    cleanFixtures();
+  });
+
+  it('exports all documents with operations, triggers, and tools', async () => {
+    const ir = await loadWorkspaceAutomationIR(FIXTURES_DIR);
+
+    expect(ir.workspace).toBe('automation-ir');
+    expect(ir.stats.documents).toBe(3);
+    expect(ir.stats.operations).toBe(3);
+    expect(ir.stats.triggers).toBe(3);
+    expect(ir.stats.tools).toBe(1);
+    expect(ir.stats.documentsByKind).toEqual({
+      document: 1,
+      playbook: 1,
+      tool: 1,
+    });
+
+    const genericDoc = ir.documents.find((document) => document.name === 'Lead Intake');
+    expect(genericDoc?.kind).toBe('document');
+    expect(genericDoc?.triggers[0]?.eventType).toBe('gmail.message.received');
+    expect(genericDoc?.operations[0]?.name).toBe('ProcessIncomingLead');
+
+    const toolDoc = ir.documents.find((document) => document.name === 'Gmail Tool');
+    expect(toolDoc?.kind).toBe('tool');
+    expect(toolDoc?.metadata.provider).toBe('composio');
+    expect(toolDoc?.tools?.[0]?.providers?.composio?.action).toBe('GMAIL_SEND_EMAIL');
+
+    const playbookDoc = ir.documents.find((document) => document.name === 'Daily Digest');
+    expect(playbookDoc?.kind).toBe('playbook');
+    expect(playbookDoc?.triggers[0]?.schedule).toBe('0 6 * * *');
+  });
+
+  it('optionally includes the dependency graph summary', async () => {
+    const ir = await loadWorkspaceAutomationIR(FIXTURES_DIR, { includeGraph: true });
+
+    expect(ir.dependencyGraph?.stats.documents).toBe(3);
+    expect(ir.dependencyGraph?.edges.some((edge) => edge.from === 'daily-digest' && edge.to === 'lead-intake')).toBe(true);
+  });
+});

--- a/packages/busy-cli/src/cli/index.ts
+++ b/packages/busy-cli/src/cli/index.ts
@@ -16,6 +16,7 @@ import {
   getPackageInfo,
 } from '../commands/package.js';
 import { loadWorkspaceGraph, formatGraph, type GraphFormat } from '../commands/graph.js';
+import { loadWorkspaceAutomationIR } from '../commands/automation-ir.js';
 
 // Read version from package.json
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -236,6 +237,40 @@ program
       }
     } catch (err) {
       console.error('Error building graph:', err instanceof Error ? err.message : err);
+      process.exit(1);
+    }
+  });
+
+// Automation IR command - output workspace automation/runtime IR
+program
+  .command('automation-ir')
+  .description('Output machine-consumable BUSY workspace automation IR')
+  .argument('[directory]', 'Workspace directory', '.')
+  .option('--include-graph', 'Include dependency graph summary in the exported IR')
+  .option('--compact', 'Emit compact JSON instead of pretty-printed output')
+  .option('-o, --output <file>', 'Output file for IR content')
+  .action(async (directory: string, options) => {
+    try {
+      const workspaceRoot = resolve(directory);
+      const ir = await loadWorkspaceAutomationIR(workspaceRoot, {
+        includeGraph: options.includeGraph,
+      });
+      const output = options.compact
+        ? JSON.stringify(ir)
+        : JSON.stringify(ir, null, 2);
+
+      if (options.output) {
+        await writeFile(options.output, output, 'utf-8');
+        console.log(`✓ Automation IR written to ${options.output}`);
+        console.log(`  Workspace: ${ir.workspace}`);
+        console.log(`  Documents: ${ir.stats.documents}`);
+        console.log(`  Operations: ${ir.stats.operations}`);
+        console.log(`  Triggers: ${ir.stats.triggers}`);
+      } else {
+        console.log(output);
+      }
+    } catch (err) {
+      console.error('Error building automation IR:', err instanceof Error ? err.message : err);
       process.exit(1);
     }
   });

--- a/packages/busy-cli/src/commands/automation-ir.ts
+++ b/packages/busy-cli/src/commands/automation-ir.ts
@@ -1,0 +1,142 @@
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import fg from 'fast-glob';
+import { parseDocument } from '../parser.js';
+import { loadWorkspaceGraph, type WorkspaceGraph } from './graph.js';
+import type {
+  Import,
+  Metadata,
+  NewOperation,
+  Tool,
+  Trigger,
+} from '../types/schema.js';
+
+export interface WorkspaceAutomationDocument {
+  id: string;
+  path: string;
+  name: string;
+  kind: 'document' | 'playbook' | 'view' | 'config' | 'tool';
+  metadata: Metadata;
+  typeLabels: string[];
+  imports: Import[];
+  operations: NewOperation[];
+  triggers: Trigger[];
+  tools?: Tool[];
+}
+
+export interface WorkspaceAutomationStats {
+  documents: number;
+  operations: number;
+  triggers: number;
+  tools: number;
+  documentsByKind: Record<string, number>;
+}
+
+export interface WorkspaceAutomationIR {
+  workspace: string;
+  root: string;
+  stats: WorkspaceAutomationStats;
+  documents: WorkspaceAutomationDocument[];
+  dependencyGraph?: WorkspaceGraph;
+}
+
+export interface LoadWorkspaceAutomationIROptions {
+  includeGraph?: boolean;
+}
+
+export async function loadWorkspaceAutomationIR(
+  workspaceRoot: string,
+  options: LoadWorkspaceAutomationIROptions = {},
+): Promise<WorkspaceAutomationIR> {
+  const normalizedRoot = path.resolve(workspaceRoot);
+  const filePaths = await discoverWorkspaceBusyFiles(normalizedRoot);
+  const documents: WorkspaceAutomationDocument[] = [];
+
+  for (const filePath of filePaths) {
+    const content = await readFile(filePath, 'utf-8');
+    const parsed = parseDocument(content);
+    const typeLabels = extractTypeLabels(parsed.metadata.type);
+    const kind = inferDocumentKind(typeLabels);
+
+    documents.push({
+      id: stripBusyExtension(toPosix(path.relative(normalizedRoot, filePath))),
+      path: toPosix(path.relative(normalizedRoot, filePath)),
+      name: parsed.metadata.name,
+      kind,
+      metadata: parsed.metadata,
+      typeLabels,
+      imports: parsed.imports,
+      operations: parsed.operations,
+      triggers: parsed.triggers,
+      ...('tools' in parsed ? { tools: parsed.tools } : {}),
+    });
+  }
+
+  documents.sort((a, b) => a.path.localeCompare(b.path));
+
+  const stats = documents.reduce<WorkspaceAutomationStats>((acc, document) => {
+    acc.documents += 1;
+    acc.operations += document.operations.length;
+    acc.triggers += document.triggers.length;
+    acc.tools += document.tools?.length ?? 0;
+    acc.documentsByKind[document.kind] = (acc.documentsByKind[document.kind] ?? 0) + 1;
+    return acc;
+  }, {
+    documents: 0,
+    operations: 0,
+    triggers: 0,
+    tools: 0,
+    documentsByKind: {},
+  });
+
+  return {
+    workspace: path.basename(normalizedRoot),
+    root: normalizedRoot,
+    stats,
+    documents,
+    ...(options.includeGraph ? { dependencyGraph: await loadWorkspaceGraph(normalizedRoot) } : {}),
+  };
+}
+
+async function discoverWorkspaceBusyFiles(workspaceRoot: string): Promise<string[]> {
+  const globs = [path.join(workspaceRoot, '**/*.busy.md')];
+  const librariesRoot = path.join(workspaceRoot, '.libraries');
+
+  if (existsSync(librariesRoot)) {
+    globs.push(path.join(librariesRoot, '**/*.busy.md'));
+  }
+
+  const filePaths = await fg(globs, {
+    absolute: true,
+    onlyFiles: true,
+  });
+
+  return filePaths.sort();
+}
+
+function extractTypeLabels(type: string): string[] {
+  return type
+    .replace(/^\[/, '')
+    .replace(/\]$/, '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+function inferDocumentKind(typeLabels: string[]): WorkspaceAutomationDocument['kind'] {
+  const normalized = typeLabels.map((value) => value.toLowerCase());
+  if (normalized.includes('tool')) return 'tool';
+  if (normalized.includes('view')) return 'view';
+  if (normalized.includes('playbook')) return 'playbook';
+  if (normalized.includes('config')) return 'config';
+  return 'document';
+}
+
+function stripBusyExtension(relPath: string): string {
+  return relPath.replace(/\.busy\.md$/, '').replace(/\.md$/, '');
+}
+
+function toPosix(filePath: string): string {
+  return filePath.split(path.sep).join('/');
+}

--- a/packages/busy-cli/src/index.ts
+++ b/packages/busy-cli/src/index.ts
@@ -1,5 +1,7 @@
 // Main exports
 export { loadRepo } from './loader.js';
+export { parseDocument, resolveImports } from './parser.js';
+export { loadWorkspaceAutomationIR } from './commands/automation-ir.js';
 export { buildContext, writeContext, get, parentsOf, childrenOf, getConceptContext } from './builders/context.js';
 export { mergeRepos, extendRepo, loadRepoFromJSON } from './merge.js';
 
@@ -23,7 +25,20 @@ export type {
   Repo,
   ContextPayload,
   FrontMatter,
+  Metadata,
+  Import,
+  Trigger,
+  NewOperation,
+  Tool,
+  ToolDocument,
 } from './types/schema.js';
+
+export type {
+  WorkspaceAutomationDocument,
+  WorkspaceAutomationStats,
+  WorkspaceAutomationIR,
+  LoadWorkspaceAutomationIROptions,
+} from './commands/automation-ir.js';
 
 export type { BuildOpts, ConceptContext } from './builders/context.js';
 


### PR DESCRIPTION
## Summary
- add a workspace-level `busy automation-ir` export built from the richer `parseDocument()` model
- expose the same automation IR through a new library API for LORE and pi-bus consumers
- preserve document operations, triggers, and tool provider mappings, with optional dependency graph inclusion

## Testing
- `cd packages/busy-cli && npm test`
- `cd packages/busy-cli && npm run build`
- `cd packages/busy-cli && node dist/cli/index.js automation-ir src/__tests__/fixtures --compact`

Closes PFM-131
