### PR TITLE
Use Node 24 for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Validate version matches tag
@@ -86,7 +86,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Validate version matches tag
         if: startsWith(github.ref, 'refs/tags/lsp-v')


### PR DESCRIPTION
## Summary

- Update the package publish workflow to use Node 24 in both publish jobs.
- Keep `publish-cli` and `publish-lsp` consistent.

## Validation

- Parsed `.github/workflows/publish.yml` with Ruby YAML parser.
- Ran `git diff --check`.
- Confirmed both `node-version` entries are now `24`.

## Publish retry evidence

Retried the CLI publish path with `workflow_dispatch` on this branch:

- Run: https://github.com/Bravo-Tensor/busy-lang/actions/runs/27856889322
- Ref: `fix/publish-workflow-node24`
- Result: failed at `npm publish --access public --provenance`
- Node used by `actions/setup-node`: `v24.16.0`
- npm version: `11.13.0`

Failure remains npm registry authorization/visibility style `E404`:

```text
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/busy-cli - Not found
npm error 404 The requested resource 'busy-cli@0.5.3' could not be found or you do not have permission to access it.
```

`busy-cli@0.5.3` is still not published; downstream `lore-core` / `pi-standard` updates should wait until npm publishing authority is fixed and the package version is visible.
